### PR TITLE
feat: 수영 기록(Memory, MemoryDetail, Stroke, Pool) 도메인 클래스 및 엔티티 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/Memory.java
@@ -12,6 +12,7 @@ public class Memory {
     private Long id;
     private Member member;
     private Pool pool;
+    private MemoryDetail memoryDetail;
     private LocalDate recordAt;
     private LocalTime startTime;
     private LocalTime endTime;
@@ -22,6 +23,7 @@ public class Memory {
             Long id,
             Member member,
             Pool pool,
+            MemoryDetail memoryDetail,
             LocalDate recordAt,
             LocalTime startTime,
             LocalTime endTime,
@@ -29,6 +31,7 @@ public class Memory {
         this.id = id;
         this.member = member;
         this.pool = pool;
+        this.memoryDetail = memoryDetail;
         this.recordAt = recordAt;
         this.startTime = startTime;
         this.endTime = endTime;

--- a/module-domain/src/main/java/com/depromeet/memory/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/Memory.java
@@ -1,0 +1,37 @@
+package com.depromeet.memory;
+
+import com.depromeet.member.Member;
+import com.depromeet.pool.Pool;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Memory {
+    private Long id;
+    private Member member;
+    private Pool pool;
+    private LocalDate recordAt;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String diary;
+
+    @Builder
+    public Memory(
+            Long id,
+            Member member,
+            Pool pool,
+            LocalDate recordAt,
+            LocalTime startTime,
+            LocalTime endTime,
+            String diary) {
+        this.id = id;
+        this.member = member;
+        this.pool = pool;
+        this.recordAt = recordAt;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.diary = diary;
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/memory/MemoryDetail.java
+++ b/module-domain/src/main/java/com/depromeet/memory/MemoryDetail.java
@@ -7,17 +7,14 @@ import lombok.Getter;
 @Getter
 public class MemoryDetail {
     private Long id;
-    private Memory memory;
     private String item;
     private Short heartRate;
     private LocalTime pace;
     private Integer kcal;
 
     @Builder
-    public MemoryDetail(
-            Long id, Memory memory, String item, Short heartRate, LocalTime pace, Integer kcal) {
+    public MemoryDetail(Long id, String item, Short heartRate, LocalTime pace, Integer kcal) {
         this.id = id;
-        this.memory = memory;
         this.item = item;
         this.heartRate = heartRate;
         this.pace = pace;

--- a/module-domain/src/main/java/com/depromeet/memory/MemoryDetail.java
+++ b/module-domain/src/main/java/com/depromeet/memory/MemoryDetail.java
@@ -1,0 +1,26 @@
+package com.depromeet.memory;
+
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemoryDetail {
+    private Long id;
+    private Memory memory;
+    private String item;
+    private Short heartRate;
+    private LocalTime pace;
+    private Integer kcal;
+
+    @Builder
+    public MemoryDetail(
+            Long id, Memory memory, String item, Short heartRate, LocalTime pace, Integer kcal) {
+        this.id = id;
+        this.memory = memory;
+        this.item = item;
+        this.heartRate = heartRate;
+        this.pace = pace;
+        this.kcal = kcal;
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/memory/Stroke.java
+++ b/module-domain/src/main/java/com/depromeet/memory/Stroke.java
@@ -1,0 +1,22 @@
+package com.depromeet.memory;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Stroke {
+    private Long id;
+    private Memory memory;
+    private String name;
+    private Short laps;
+    private Integer meter;
+
+    @Builder
+    public Stroke(Long id, Memory memory, String name, Short laps, Integer meter) {
+        this.id = id;
+        this.memory = memory;
+        this.name = name;
+        this.laps = laps;
+        this.meter = meter;
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/pool/Pool.java
+++ b/module-domain/src/main/java/com/depromeet/pool/Pool.java
@@ -1,0 +1,18 @@
+package com.depromeet.pool;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Pool {
+    private Long id;
+    private String name;
+    private Integer lane;
+
+    @Builder
+    public Pool(Long id, String name, Integer lane) {
+        this.id = id;
+        this.name = name;
+        this.lane = lane;
+    }
+}

--- a/module-infrastructure/persistence-database/build.gradle
+++ b/module-infrastructure/persistence-database/build.gradle
@@ -5,5 +5,6 @@ dependencies {
     implementation project(':module-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
     runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
@@ -38,6 +38,16 @@ public class MemoryDetailEntity {
         this.kcal = kcal;
     }
 
+    public static MemoryDetailEntity from(MemoryDetail memoryDetail) {
+        return MemoryDetailEntity.builder()
+                .id(memoryDetail.getId())
+                .item(memoryDetail.getItem())
+                .heartRate(memoryDetail.getHeartRate())
+                .pace(memoryDetail.getPace())
+                .kcal(memoryDetail.getKcal())
+                .build();
+    }
+
     public MemoryDetail toModel() {
         return MemoryDetail.builder()
                 .id(this.id)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
@@ -39,6 +39,8 @@ public class MemoryDetailEntity {
     }
 
     public static MemoryDetailEntity from(MemoryDetail memoryDetail) {
+        if (memoryDetail == null) return null;
+
         return MemoryDetailEntity.builder()
                 .id(memoryDetail.getId())
                 .item(memoryDetail.getItem())

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
@@ -1,0 +1,50 @@
+package com.depromeet.memory.entity;
+
+import com.depromeet.memory.MemoryDetail;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryDetailEntity {
+    @Id
+    @Column(name = "memory_detail_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String item;
+
+    private Short heartRate;
+
+    private LocalTime pace;
+
+    private Integer kcal;
+
+    @Builder
+    public MemoryDetailEntity(Long id, String item, Short heartRate, LocalTime pace, Integer kcal) {
+        this.id = id;
+        this.item = item;
+        this.heartRate = heartRate;
+        this.pace = pace;
+        this.kcal = kcal;
+    }
+
+    public MemoryDetail toModel() {
+        return MemoryDetail.builder()
+                .id(this.id)
+                .item(this.item)
+                .heartRate(this.heartRate)
+                .pace(this.pace)
+                .kcal(this.kcal)
+                .build();
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -71,6 +71,19 @@ public class MemoryEntity {
         this.diary = diary;
     }
 
+    public static MemoryEntity from(Memory memory) {
+        return MemoryEntity.builder()
+                .id(memory.getId())
+                .member(MemberEntity.from(memory.getMember()))
+                .pool(PoolEntity.from(memory.getPool()))
+                .memoryDetail(MemoryDetailEntity.from(memory.getMemoryDetail()))
+                .recordAt(memory.getRecordAt())
+                .startTime(memory.getStartTime())
+                .endTime(memory.getEndTime())
+                .diary(memory.getDiary())
+                .build();
+    }
+
     public Memory toModel() {
         return Memory.builder()
                 .id(this.id)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -49,6 +49,7 @@ public class MemoryEntity {
 
     @NotNull private LocalTime endTime;
 
+    @Column(columnDefinition = "TEXT")
     private String diary;
 
     @Builder

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -35,8 +35,8 @@ public class MemoryEntity {
     private MemberEntity member;
 
     @NotNull
-    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pool_id")
+    @OneToOne(fetch = FetchType.LAZY)
     private PoolEntity pool;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -1,0 +1,90 @@
+package com.depromeet.memory.entity;
+
+import com.depromeet.member.entity.MemberEntity;
+import com.depromeet.memory.Memory;
+import com.depromeet.pool.entity.PoolEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryEntity {
+    @Id
+    @Column(name = "memory_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity member;
+
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pool_id")
+    private PoolEntity pool;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memory_detail_id")
+    private MemoryDetailEntity memoryDetail;
+
+    @NotNull private LocalDate recordAt;
+
+    @NotNull private LocalTime startTime;
+
+    @NotNull private LocalTime endTime;
+
+    private String diary;
+
+    @Builder
+    public MemoryEntity(
+            Long id,
+            MemberEntity member,
+            PoolEntity pool,
+            MemoryDetailEntity memoryDetail,
+            LocalDate recordAt,
+            LocalTime startTime,
+            LocalTime endTime,
+            String diary) {
+        this.id = id;
+        this.member = member;
+        this.pool = pool;
+        this.memoryDetail = memoryDetail;
+        this.recordAt = recordAt;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.diary = diary;
+    }
+
+    public Memory toModel() {
+        return Memory.builder()
+                .id(this.id)
+                .member(this.member.toModel())
+                .pool(this.pool.toModel())
+                .memoryDetail(this.memoryDetail.toModel())
+                .recordAt(this.recordAt)
+                .startTime(this.startTime)
+                .endTime(this.endTime)
+                .diary(this.diary)
+                .build();
+    }
+
+    public String updateDiary(String diary) {
+        return this.diary = diary;
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/StrokeEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/StrokeEntity.java
@@ -1,0 +1,56 @@
+package com.depromeet.memory.entity;
+
+import com.depromeet.memory.Stroke;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StrokeEntity {
+    @Id
+    @Column(name = "stroke_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @JoinColumn(name = "memory_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemoryEntity memory;
+
+    private String name;
+
+    private Short laps;
+
+    private Integer meter;
+
+    @Builder
+    public StrokeEntity(Long id, MemoryEntity memory, String name, Short laps, Integer meter) {
+        this.id = id;
+        this.memory = memory;
+        this.name = name;
+        this.laps = laps;
+        this.meter = meter;
+    }
+
+    public Stroke toModel() {
+        return Stroke.builder()
+                .id(this.id)
+                .memory(this.memory.toModel())
+                .name(this.name)
+                .laps(this.laps)
+                .meter(this.meter)
+                .build();
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/StrokeEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/StrokeEntity.java
@@ -44,6 +44,16 @@ public class StrokeEntity {
         this.meter = meter;
     }
 
+    public static StrokeEntity from(Stroke stroke) {
+        return StrokeEntity.builder()
+                .id(stroke.getId())
+                .memory(MemoryEntity.from(stroke.getMemory()))
+                .name(stroke.getName())
+                .laps(stroke.getLaps())
+                .meter(stroke.getMeter())
+                .build();
+    }
+
     public Stroke toModel() {
         return Stroke.builder()
                 .id(this.id)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/entity/PoolEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/entity/PoolEntity.java
@@ -1,0 +1,37 @@
+package com.depromeet.pool.entity;
+
+import com.depromeet.pool.Pool;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PoolEntity {
+    @Id
+    @Column(name = "pool_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Integer lane;
+
+    @Builder
+    public PoolEntity(Long id, String name, Integer lane) {
+        this.id = id;
+        this.name = name;
+        this.lane = lane;
+    }
+
+    public Pool toModel() {
+        return Pool.builder().id(this.id).name(this.name).lane(this.lane).build();
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/entity/PoolEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/entity/PoolEntity.java
@@ -31,6 +31,14 @@ public class PoolEntity {
         this.lane = lane;
     }
 
+    public static PoolEntity from(Pool pool) {
+        return PoolEntity.builder()
+                .id(pool.getId())
+                .name(pool.getName())
+                .lane(pool.getLane())
+                .build();
+    }
+
     public Pool toModel() {
         return Pool.builder().id(this.id).name(this.name).lane(this.lane).build();
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #20 

## 📌 작업 내용 및 특이사항
- Memory, MemoryDetail, Stroke, Pool 도메인 클래스 및 엔티티를 구현하였습니다.
- 도메인 클래스와 엔티티 간 변환하는 로직은 Entity 클래스 내 `from()`, `toModel()`로 구현하였습니다.
- 엔티티 클래스에는 `@Column(nullable = false)` 가 아닌 `hibernate validation`의 `@NotNull`을 이용하여 어플리케이션과 DB 단 모두에서 NotNull을 검증하도록 하였습니다.
- Memory의 MemoryDetail은 Nullable 하므로 `MemoryEntity.from(Memory memory)` 수행 시 내부에서 `MemoryDetailEntity.from(MemoryDetailEntity memoryDetailEntity)`가 수행되는데 null 시 null을 반환하여 쓰레기 객체가 저장되지 않도록 하였습니다.
- 또한 `@OneToOne` 외래키의 주인은 양쪽 중 어디에 설정할지 결정할 수 있습니다. 
- `Memory - MemoryDetail` 간 Memory를 고른 이유는 Memory 조회 시 직접 참조 가능하다는 점에서 지정하였습니다. `Memory - Pool`의 경우에 Pool에 Memory와 관련된 필드를 담게 되면 추후 수영장 관련 서비스를 확장 시에 제약사항이 될 것이라고 판단하여 Memory 측에 필드를 설정하였습니다.

## 📝 참고사항
- `@Column(nullable = false)와 @NotNull의 비교` : https://kafcamus.tistory.com/15

<img width="617" alt="image" src="https://github.com/depromeet/15th-team2-BE/assets/48898994/5637aad8-70b7-45ab-aee8-5398d03733a3">

