### PR TITLE
feat: Jenkins CI/CD 구현

### DIFF
--- a/scripts/Dockerfile-dev
+++ b/scripts/Dockerfile-dev
@@ -1,0 +1,7 @@
+FROM amazoncorretto:21
+
+WORKDIR /app
+
+COPY module-presentation/build/libs/module-presentation.jar /app/appu.jar
+
+CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=dev", "appu.jar"]

--- a/scripts/Dockerfile-prod
+++ b/scripts/Dockerfile-prod
@@ -1,0 +1,7 @@
+FROM amazoncorretto:21
+
+WORKDIR /app
+
+COPY module-presentation/build/libs/module-presentation.jar /app/appu.jar
+
+CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=prod", "appu.jar"]

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -36,9 +36,7 @@ pipeline {
         stage('Docker 이미지 빌드') {
             steps {
                 script {
-                    sh 'pwd'
                     sh 'cp ./module-presentation/build/libs/module-presentation.jar .'
-                    sh 'pwd'
                     dockerImage = docker.build(repository + ":latest", "-f ./scripts/Dockerfile-prod .")
                 }
             }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,0 +1,74 @@
+pipeline {
+    agent any
+    tools {
+        gradle 'gradle'
+        jdk("JDK 21")
+    }
+    triggers {
+        githubPush()
+    }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '3'))
+    }
+    environment {
+        docker_usr = credentials('DOCKERHUB_CREDENTIALS_USR')
+        docker_psw = credentials('DOCKERHUB_CREDENTIALS_PSW')
+        repository = credentials('DOCKERHUB_REPOSITORY')
+        TARGET_HOST = credentials('REMOTE_SERVER_ADDR')
+        dockerImage = ''
+    }
+    stages {
+        stage('저장소 복제') {
+            steps {
+                git branch: 'main', credentialsId: 'GITHUB_ACCESS_TOKEN', url: 'https://github.com/depromeet/15th-team2-BE'
+            }
+        }
+
+        stage('빌드') {
+            steps {
+                sh 'chmod u+w ./module-presentation/src/main/resources/'
+                sh 'cp ~/application-secret.properties ./module-presentation/src/main/resources/'
+                sh 'chmod +x ./gradlew'
+                sh ' ./gradlew :module-presentation:build'
+            }
+        }
+
+        stage('Docker 이미지 빌드') {
+            steps {
+                script {
+                    sh 'pwd'
+                    sh 'cp ./module-presentation/build/libs/module-presentation.jar .'
+                    sh 'pwd'
+                    dockerImage = docker.build(repository + ":latest", "-f ./scripts/Dockerfile-prod .")
+                }
+            }
+        }
+
+        stage('Dockerhub 로그인') {
+            steps {
+                sh 'echo $docker_psw | docker login -u $docker_usr --password-stdin'
+            }
+        }
+
+        stage('Dockerhub에 Push') {
+            steps {
+                sh 'docker push ${repository}:latest'
+            }
+        }
+
+        stage('원격 서버에 접속하여 deploy 스크립트 실행') {
+            steps {
+                script {
+                    def remoteCommands = """
+                        cd ~ &&
+                        ./deploy.sh
+                    """
+
+                    sshagent (credentials: ['jenkins-ssh']) {
+                        sh "ssh -o StrictHostKeyChecking=no ${TARGET_HOST} '${remoteCommands}'"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/Jenkinsfile-dev
+++ b/scripts/Jenkinsfile-dev
@@ -1,0 +1,74 @@
+pipeline {
+    agent any
+    tools {
+        gradle 'gradle'
+        jdk("JDK 21")
+    }
+    triggers {
+        githubPush()
+    }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '3'))
+    }
+    environment {
+        docker_usr = credentials('DOCKERHUB_CREDENTIALS_USR')
+        docker_psw = credentials('DOCKERHUB_CREDENTIALS_PSW')
+        repository = credentials('DOCKERHUB_REPOSITORY')
+        TARGET_HOST = credentials('DEV_SERVER_ADDR')
+        dockerImage = ''
+    }
+    stages {
+        stage('저장소 복제') {
+            steps {
+                git branch: 'develop', credentialsId: 'GITHUB_ACCESS_TOKEN', url: 'https://github.com/depromeet/15th-team2-BE'
+            }
+        }
+
+        stage('빌드') {
+            steps {
+                sh 'chmod u+w ./module-presentation/src/main/resources/'
+                sh 'cp ~/application-secret.properties ./module-presentation/src/main/resources/'
+                sh 'chmod +x ./gradlew'
+                sh ' ./gradlew :module-presentation:build'
+            }
+        }
+
+        stage('Docker 이미지 빌드') {
+            steps {
+                script {
+                    sh 'pwd'
+                    sh 'cp ./module-presentation/build/libs/module-presentation.jar .'
+                    sh 'pwd'
+                    dockerImage = docker.build(repository + ":latest", "-f ./scripts/Dockerfile-dev .")
+                }
+            }
+        }
+
+        stage('Dockerhub 로그인') {
+            steps {
+                sh 'echo $docker_psw | docker login -u $docker_usr --password-stdin'
+            }
+        }
+
+        stage('Dockerhub에 Push') {
+            steps {
+                sh 'docker push ${repository}:latest'
+            }
+        }
+
+        stage('원격 서버에 접속하여 deploy 스크립트 실행') {
+            steps {
+                script {
+                    def remoteCommands = """
+                        cd ~ &&
+                        ./deploy.sh
+                    """
+
+                    sshagent (credentials: ['jenkins-ssh']) {
+                        sh "ssh -o StrictHostKeyChecking=no ${TARGET_HOST} '${remoteCommands}'"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/Jenkinsfile-dev
+++ b/scripts/Jenkinsfile-dev
@@ -36,9 +36,7 @@ pipeline {
         stage('Docker 이미지 빌드') {
             steps {
                 script {
-                    sh 'pwd'
                     sh 'cp ./module-presentation/build/libs/module-presentation.jar .'
-                    sh 'pwd'
                     dockerImage = docker.build(repository + ":latest", "-f ./scripts/Dockerfile-dev .")
                 }
             }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #29 

## 📌 작업 내용 및 특이사항
- CI/CD를 위한 Dockerfile, Jenkinsfile을 scripts 디렉토리 내에 구현하였습니다.
- Dockerfile-dev와 Dockerfile-prod는 `spring.profiles.active`만 다르게 구현하였습니다.
- Jenkinsfile, Jenkinsfile-dev는 내부에 들어가는 credential 값만 다르게 구현하였습니다.
- dev는 develop 브랜치에 merge됐을 때 dev 서버에 배포되도록 코드를 두었습니다. (현재는 개발 서버가 존재하지 않기에 동작하지 않습니다)
- prod는 main 브랜치에 merge됐을 때 prod 서버에 배포되도록 구현하였습니다.

## 📝 참고사항
-