### PR TITLE
feat: 수영장 검색 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/application-secret.properties
+**/data.sql
 
 ### STS ###
 .apt_generated

--- a/module-independent/src/main/java/com/depromeet/type/pool/PoolSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/pool/PoolSuccessType.java
@@ -1,0 +1,25 @@
+package com.depromeet.type.pool;
+
+import com.depromeet.type.SuccessType;
+
+public enum PoolSuccessType implements SuccessType {
+    SEARCH_SUCCESS("POOL_1", "수영장 검색을 성공하였습니다");
+
+    private final String code;
+    private final String message;
+
+    PoolSuccessType(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/module-infrastructure/persistence-database/build.gradle
+++ b/module-infrastructure/persistence-database/build.gradle
@@ -9,4 +9,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     testRuntimeOnly 'com.h2database:h2'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/QuerydslConfig.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package com.depromeet.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    JPAQueryFactory queryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolJpaRepository.java
@@ -1,0 +1,9 @@
+package com.depromeet.pool.repository;
+
+import com.depromeet.pool.entity.PoolEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PoolJpaRepository extends JpaRepository<PoolEntity, Long> {
+    List<PoolEntity> findTop3PoolsByNameContaining(String query);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
@@ -4,5 +4,5 @@ import com.depromeet.pool.Pool;
 import java.util.List;
 
 public interface PoolRepository {
-    List<Pool> findPoolsByName(String query);
+    List<Pool> findPoolsByName(String nameQuery);
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
@@ -1,0 +1,8 @@
+package com.depromeet.pool.repository;
+
+import com.depromeet.pool.Pool;
+import java.util.List;
+
+public interface PoolRepository {
+    List<Pool> findPoolsByName(String query);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepositoryImpl.java
@@ -17,9 +17,9 @@ public class PoolRepositoryImpl implements PoolRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Pool> findPoolsByName(String query) {
+    public List<Pool> findPoolsByName(String nameQuery) {
         List<PoolEntity> findPools =
-                queryFactory.selectFrom(poolEntity).where(nameLike(query)).limit(3).fetch();
+                queryFactory.selectFrom(poolEntity).where(nameLike(nameQuery)).limit(3).fetch();
 
         return findPools.stream().map(PoolEntity::toModel).toList();
     }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.depromeet.pool.repository;
+
+import static com.depromeet.pool.entity.QPoolEntity.*;
+
+import com.depromeet.pool.Pool;
+import com.depromeet.pool.entity.PoolEntity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PoolRepositoryImpl implements PoolRepository {
+    private final PoolJpaRepository poolJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Pool> findPoolsByName(String query) {
+        List<PoolEntity> findPools =
+                queryFactory.selectFrom(poolEntity).where(nameLike(query)).limit(3).fetch();
+
+        return findPools.stream().map(PoolEntity::toModel).toList();
+    }
+
+    private BooleanExpression nameLike(String query) {
+        BooleanExpression whereExpression = poolEntity.isNotNull();
+
+        if (query != null && !query.isEmpty()) {
+            whereExpression = poolEntity.name.contains(query);
+        }
+
+        return whereExpression;
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolApi.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolApi.java
@@ -1,0 +1,14 @@
+package com.depromeet.pool.api;
+
+import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.pool.dto.response.PoolResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "수영장(Pool)")
+public interface PoolApi {
+    @Operation(summary = "수영장 검색")
+    public ApiResponse<PoolResponseDto> searchPoolsByName(
+            @RequestParam(required = false) String query);
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -18,8 +18,8 @@ public class PoolController {
 
     @GetMapping("/search")
     public ApiResponse<PoolResponseDto> searchPoolsByName(
-            @RequestParam(required = false) String query) {
+            @RequestParam(required = false) String nameQuery) {
         return ApiResponse.success(
-                PoolSuccessType.SEARCH_SUCCESS, poolService.findPoolsByName(query));
+                PoolSuccessType.SEARCH_SUCCESS, poolService.findPoolsByName(nameQuery));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -5,13 +5,11 @@ import com.depromeet.pool.dto.response.PoolResponseDto;
 import com.depromeet.pool.service.PoolService;
 import com.depromeet.type.pool.PoolSuccessType;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/pool")

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -1,0 +1,27 @@
+package com.depromeet.pool.api;
+
+import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.pool.dto.response.PoolResponseDto;
+import com.depromeet.pool.service.PoolService;
+import com.depromeet.type.pool.PoolSuccessType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/pool")
+public class PoolController {
+    private final PoolService poolService;
+
+    @GetMapping("/search")
+    public ApiResponse<PoolResponseDto> searchPoolsByName(
+            @RequestParam(required = false) String query) {
+        return ApiResponse.success(
+                PoolSuccessType.SEARCH_SUCCESS, poolService.findPoolsByName(query));
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/pool")
-public class PoolController {
+public class PoolController implements PoolApi {
     private final PoolService poolService;
 
     @GetMapping("/search")

--- a/module-presentation/src/main/java/com/depromeet/pool/dto/request/PoolSearchRequestDto.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/dto/request/PoolSearchRequestDto.java
@@ -1,0 +1,3 @@
+package com.depromeet.pool.dto.request;
+
+public record PoolSearchRequestDto() {}

--- a/module-presentation/src/main/java/com/depromeet/pool/dto/request/PoolSearchRequestDto.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/dto/request/PoolSearchRequestDto.java
@@ -1,3 +1,0 @@
-package com.depromeet.pool.dto.request;
-
-public record PoolSearchRequestDto() {}

--- a/module-presentation/src/main/java/com/depromeet/pool/dto/response/PoolInfoDto.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/dto/response/PoolInfoDto.java
@@ -1,0 +1,9 @@
+package com.depromeet.pool.dto.response;
+
+import com.depromeet.pool.Pool;
+
+public record PoolInfoDto(Long poolId, String name) {
+    public static PoolInfoDto of(Pool pool) {
+        return new PoolInfoDto(pool.getId(), pool.getName());
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/dto/response/PoolResponseDto.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/dto/response/PoolResponseDto.java
@@ -1,0 +1,13 @@
+package com.depromeet.pool.dto.response;
+
+import com.depromeet.pool.Pool;
+import java.util.List;
+
+public record PoolResponseDto(List<PoolInfoDto> poolInfos) {
+    public static PoolResponseDto of(List<Pool> pools) {
+        if (pools == null) {
+            return new PoolResponseDto(null);
+        }
+        return new PoolResponseDto(pools.stream().map(PoolInfoDto::of).toList());
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/service/PoolService.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/service/PoolService.java
@@ -3,5 +3,5 @@ package com.depromeet.pool.service;
 import com.depromeet.pool.dto.response.PoolResponseDto;
 
 public interface PoolService {
-    PoolResponseDto findPoolsByName(String requestPoolName);
+    PoolResponseDto findPoolsByName(String nameQuery);
 }

--- a/module-presentation/src/main/java/com/depromeet/pool/service/PoolService.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/service/PoolService.java
@@ -1,0 +1,7 @@
+package com.depromeet.pool.service;
+
+import com.depromeet.pool.dto.response.PoolResponseDto;
+
+public interface PoolService {
+    PoolResponseDto findPoolsByName(String requestPoolName);
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/service/PoolServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/service/PoolServiceImpl.java
@@ -1,0 +1,22 @@
+package com.depromeet.pool.service;
+
+import com.depromeet.pool.Pool;
+import com.depromeet.pool.dto.response.PoolResponseDto;
+import com.depromeet.pool.repository.PoolRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PoolServiceImpl implements PoolService {
+    private final PoolRepository poolRepository;
+
+    @Override
+    public PoolResponseDto findPoolsByName(String query) {
+        List<Pool> findPools = poolRepository.findPoolsByName(query);
+        return PoolResponseDto.of(findPools);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/pool/service/PoolServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/service/PoolServiceImpl.java
@@ -15,8 +15,8 @@ public class PoolServiceImpl implements PoolService {
     private final PoolRepository poolRepository;
 
     @Override
-    public PoolResponseDto findPoolsByName(String query) {
-        List<Pool> findPools = poolRepository.findPoolsByName(query);
+    public PoolResponseDto findPoolsByName(String nameQuery) {
+        List<Pool> findPools = poolRepository.findPoolsByName(nameQuery);
         return PoolResponseDto.of(findPools);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/security/filter/JwtAuthenticationFilter.java
+++ b/module-presentation/src/main/java/com/depromeet/security/filter/JwtAuthenticationFilter.java
@@ -93,6 +93,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     addReissuedJwtTokenToHeader(response, accessToken, refreshToken);
             setAuthentication(reissuedAccessToken);
         }
+        filterChain.doFilter(request, response);
     }
 
     private boolean noAuthentication(String url) {

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -6,10 +6,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create # 실제 서버에서 사용시 모든 데이터가 다 날아가므로 주의
+    defer-datasource-initialization: false
     properties:
       hibernate:
         format_sql: true
     show-sql: true
+  sql:
+    init:
+      mode: never
   servlet:
     multipart:
       enabled: true


### PR DESCRIPTION
## 🌱 관련 이슈

- close #33 

## 📌 작업 내용 및 특이사항
- 수영장 검색 API를 구현하였습니다.
- 검색 조건을 동적으로 수정해야 합니다. ex. 검색에 아무것도 넣지 않았을 때, 검색에 특정 값을 넣었을 때를 동시에 다뤄야함.
- 동적 검색 API를 구현하기 위해 QueryDSL을 선택하였습니다.
- jOOQ와 같은 옵션이 있었지만 JPA와 원활하게 접목하여 사용하기 쉽지 않을 것 같아 QueryDSL을 선택하였습니다.
- 수영장 검색은 인증작업만 필요할 것 같아 Service 로직에서 권한을 검사하는 부분은 생략하였습니다.

## 📝 참고사항
### `아무 검색 조건이 없을 때`
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/64af29db-0fd5-4054-bf47-59603a4b3b65">

### `특정 조건을 넣어서 검색 결과가 있을 때`
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/82917476-6295-4e14-806f-e252028b3d5f">

### `조건을 넣었지만 검색 결과가 없을 때`
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/ce51ca53-7ac8-4081-9c0c-e0f5ced4712a">

