### PR TITLE
feat: 이미지 업로드/수정/조회/삭제 기능 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/image/Image.java
+++ b/module-domain/src/main/java/com/depromeet/image/Image.java
@@ -1,0 +1,42 @@
+package com.depromeet.image;
+
+import com.depromeet.memory.Memory;
+import java.util.Optional;
+import lombok.Builder;
+
+public class Image {
+    private Long id;
+    private Memory memory;
+    private String imageName;
+    private String imageUrl;
+
+    @Builder
+    public Image(Long id, Memory memory, String imageName, String imageUrl) {
+        this.id = id;
+        this.memory = memory;
+        this.imageName = imageName;
+        this.imageUrl = imageUrl;
+    }
+
+    public void addMemoryToImage(Memory memory) {
+        if (memory != null) {
+            this.memory = memory;
+        }
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public Optional<Memory> getMemory() {
+        return Optional.ofNullable(this.memory);
+    }
+
+    public String getImageName() {
+        return this.imageName;
+    }
+
+    public String getImageUrl() {
+        return this.imageUrl;
+    }
+}

--- a/module-independent/src/main/java/com/depromeet/type/image/ImageErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/image/ImageErrorType.java
@@ -1,0 +1,25 @@
+package com.depromeet.type.image;
+
+import com.depromeet.type.ErrorType;
+
+public enum ImageErrorType implements ErrorType {
+    NOT_FOUND("IMAGE_1", "이미지가 존재하지 않습니다");
+
+    private final String code;
+    private final String message;
+
+    ImageErrorType(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/module-independent/src/main/java/com/depromeet/type/image/ImageSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/image/ImageSuccessType.java
@@ -1,0 +1,30 @@
+package com.depromeet.type.image;
+
+import com.depromeet.type.SuccessType;
+
+public enum ImageSuccessType implements SuccessType {
+    UPLOAD_IMAGES_SUCCESS("IMAGE_1", "이미지 업로드에 성공하였습니다"),
+    ADD_MEMORY_TO_IMAGES_SUCCESS("IMAGE_2", "이미지에 memory를 추가하는데 성공하였습니다."),
+    UPDATE_IMAGES_SUCCESS("IMAGE_3", "이미지 수정에 성공하였습니다"),
+    GET_IMAGES_SUCCESS("IMAGE_4", "이미지 조회에 성공하였습니다"),
+    DELETE_IMAGES_SUCCESS("IMAGE_5", "memory에 해당하는 이미지를 삭제하는데 성공하였습니다.");
+
+    private final String code;
+
+    private final String message;
+
+    ImageSuccessType(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/module-independent/src/main/java/com/depromeet/type/image/ImageSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/image/ImageSuccessType.java
@@ -4,10 +4,10 @@ import com.depromeet.type.SuccessType;
 
 public enum ImageSuccessType implements SuccessType {
     UPLOAD_IMAGES_SUCCESS("IMAGE_1", "이미지 업로드에 성공하였습니다"),
-    ADD_MEMORY_TO_IMAGES_SUCCESS("IMAGE_2", "이미지에 memory를 추가하는데 성공하였습니다."),
+    ADD_MEMORY_TO_IMAGES_SUCCESS("IMAGE_2", "이미지에 memory를 추가하는데 성공하였습니다"),
     UPDATE_IMAGES_SUCCESS("IMAGE_3", "이미지 수정에 성공하였습니다"),
     GET_IMAGES_SUCCESS("IMAGE_4", "이미지 조회에 성공하였습니다"),
-    DELETE_IMAGES_SUCCESS("IMAGE_5", "memory에 해당하는 이미지를 삭제하는데 성공하였습니다.");
+    DELETE_IMAGES_SUCCESS("IMAGE_5", "memory에 해당하는 이미지를 삭제하는데 성공하였습니다");
 
     private final String code;
 

--- a/module-independent/src/main/java/com/depromeet/util/ImageNameUtil.java
+++ b/module-independent/src/main/java/com/depromeet/util/ImageNameUtil.java
@@ -1,0 +1,13 @@
+package com.depromeet.util;
+
+import java.util.UUID;
+
+public class ImageNameUtil {
+    public static String createImageName(
+            String originalImageName, String contentType, Long fileSize) {
+        String imageName = originalImageName + "_" + contentType + "_" + fileSize;
+        UUID imageUUID = UUID.nameUUIDFromBytes(imageName.getBytes());
+
+        return imageUUID.toString();
+    }
+}

--- a/module-infrastructure/persistence-database/build.gradle
+++ b/module-infrastructure/persistence-database/build.gradle
@@ -7,4 +7,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testRuntimeOnly 'com.h2database:h2'
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/entity/ImageEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/entity/ImageEntity.java
@@ -21,13 +21,9 @@ public class ImageEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private MemoryEntity memory;
 
-    @NotNull
-    @Column(name = "image_name")
-    private String imageName;
+    @NotNull private String imageName;
 
-    @NotNull
-    @Column(name = "image_url")
-    private String imageUrl;
+    @NotNull private String imageUrl;
 
     @Builder
     public ImageEntity(Long id, MemoryEntity memory, String imageName, String imageUrl) {

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/entity/ImageEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/entity/ImageEntity.java
@@ -1,0 +1,75 @@
+package com.depromeet.image.entity;
+
+import com.depromeet.image.Image;
+import com.depromeet.memory.entity.MemoryEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageEntity {
+    @Id
+    @Column(name = "image_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "memory_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemoryEntity memory;
+
+    @NotNull
+    @Column(name = "image_name")
+    private String imageName;
+
+    @NotNull
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public ImageEntity(Long id, MemoryEntity memory, String imageName, String imageUrl) {
+        this.id = id;
+        this.memory = memory;
+        this.imageName = imageName;
+        this.imageUrl = imageUrl;
+    }
+
+    public static ImageEntity from(Image image) {
+        return ImageEntity.builder()
+                .id(image.getId())
+                .memory(
+                        image.getMemory().isPresent()
+                                ? MemoryEntity.from(image.getMemory().get())
+                                : null)
+                .imageName(image.getImageName())
+                .imageUrl(image.getImageUrl())
+                .build();
+    }
+
+    public Image toModel() {
+        return Image.builder()
+                .id(this.id)
+                .memory(this.memory.toModel())
+                .imageName(this.imageName)
+                .imageUrl(this.imageUrl)
+                .build();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public MemoryEntity getMemory() {
+        return memory;
+    }
+
+    public String getImageName() {
+        return imageName;
+    }
+
+    public @NotNull String getImageUrl() {
+        return imageUrl;
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/entity/ImageEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/entity/ImageEntity.java
@@ -4,6 +4,7 @@ import com.depromeet.image.Image;
 import com.depromeet.memory.entity.MemoryEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -51,25 +52,25 @@ public class ImageEntity {
     public Image toModel() {
         return Image.builder()
                 .id(this.id)
-                .memory(this.memory.toModel())
+                .memory(this.memory == null ? null : this.memory.toModel())
                 .imageName(this.imageName)
                 .imageUrl(this.imageUrl)
                 .build();
     }
 
     public Long getId() {
-        return id;
+        return this.id;
     }
 
-    public MemoryEntity getMemory() {
-        return memory;
+    public Optional<MemoryEntity> getMemory() {
+        return Optional.ofNullable(this.memory);
     }
 
     public String getImageName() {
-        return imageName;
+        return this.imageName;
     }
 
-    public @NotNull String getImageUrl() {
-        return imageUrl;
+    public String getImageUrl() {
+        return this.imageUrl;
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageJpaRepository.java
@@ -6,13 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ImageJpaRepository extends JpaRepository<ImageEntity, Long> {
-    List<ImageEntity> findByMemoryId(Long memoryImageId);
+    List<ImageEntity> findByMemoryId(Long memoryId);
 
-    @Query(
-            value =
-                    """
-            select image \
-            from ImageEntity image \
-            where image.id = :ids""")
+    @Query(value = """
+    select i from ImageEntity i where i.id in :ids
+    """)
     List<ImageEntity> findAllByIds(List<Long> ids);
+
+    void deleteAllByMemoryId(Long memoryId);
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageJpaRepository.java
@@ -1,0 +1,18 @@
+package com.depromeet.image.repository;
+
+import com.depromeet.image.entity.ImageEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ImageJpaRepository extends JpaRepository<ImageEntity, Long> {
+    List<ImageEntity> findByMemoryId(Long memoryImageId);
+
+    @Query(
+            value =
+                    """
+            select image \
+            from ImageEntity image \
+            where image.id = :ids""")
+    List<ImageEntity> findAllByIds(List<Long> ids);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -1,0 +1,21 @@
+package com.depromeet.image.repository;
+
+import com.depromeet.image.Image;
+import java.util.List;
+import java.util.Optional;
+
+public interface ImageRepository {
+    Long save(Image image);
+
+    List<Long> saveAll(List<Image> images);
+
+    Optional<Image> findById(Long id);
+
+    List<Image> findImagesByMemoryId(Long memoryId);
+
+    List<Image> findImageByIds(List<Long> ids);
+
+    void deleteById(Long id);
+
+    void deleteAllByIds(List<Long> ids);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -18,4 +18,6 @@ public interface ImageRepository {
     void deleteById(Long id);
 
     void deleteAllByIds(List<Long> ids);
+
+    void deleteAllByMemoryId(Long memoryId);
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepositoryImpl.java
@@ -53,4 +53,9 @@ public class ImageRepositoryImpl implements ImageRepository {
     public void deleteAllByIds(List<Long> ids) {
         imageJpaRepository.deleteAllById(ids);
     }
+
+    @Override
+    public void deleteAllByMemoryId(Long memoryId) {
+        imageJpaRepository.deleteAllByMemoryId(memoryId);
+    }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.depromeet.image.repository;
+
+import com.depromeet.image.Image;
+import com.depromeet.image.entity.ImageEntity;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ImageRepositoryImpl implements ImageRepository {
+    private final ImageJpaRepository imageJpaRepository;
+
+    @Override
+    public Long save(Image image) {
+        ImageEntity imageEntity = imageJpaRepository.save(ImageEntity.from(image));
+        return imageEntity.getId();
+    }
+
+    @Override
+    public List<Long> saveAll(List<Image> images) {
+        List<ImageEntity> memoryImageEntities = images.stream().map(ImageEntity::from).toList();
+
+        return imageJpaRepository.saveAll(memoryImageEntities).stream()
+                .map(ImageEntity::getId)
+                .toList();
+    }
+
+    @Override
+    public Optional<Image> findById(Long id) {
+        return imageJpaRepository.findById(id).map(ImageEntity::toModel);
+    }
+
+    @Override
+    public List<Image> findImagesByMemoryId(Long memoryId) {
+        return imageJpaRepository.findByMemoryId(memoryId).stream()
+                .map(ImageEntity::toModel)
+                .toList();
+    }
+
+    @Override
+    public List<Image> findImageByIds(List<Long> ids) {
+        return imageJpaRepository.findAllByIds(ids).stream().map(ImageEntity::toModel).toList();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        imageJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public void deleteAllByIds(List<Long> ids) {
+        imageJpaRepository.deleteAllById(ids);
+    }
+}

--- a/module-presentation/build.gradle
+++ b/module-presentation/build.gradle
@@ -20,4 +20,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // s3
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 }

--- a/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
+++ b/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
@@ -9,6 +9,7 @@ import jakarta.validation.UnexpectedTypeException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -41,6 +43,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(UnexpectedTypeException.class)
     public ResponseEntity<ApiResponse<?>> handleUnexpectedTypeException(
             final UnexpectedTypeException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INVALID_TYPE, 400), HttpStatus.BAD_REQUEST);
     }
@@ -48,6 +51,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<?>> handlerMethodArgumentTypeMismatchException(
             final MethodArgumentTypeMismatchException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INVALID_TYPE, 400), HttpStatus.BAD_REQUEST);
     }
@@ -55,6 +59,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(MissingRequestHeaderException.class)
     public ResponseEntity<ApiResponse<?>> handlerMissingRequestHeaderException(
             final MissingRequestHeaderException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INVALID_MISSING_HEADER, 400),
                 HttpStatus.BAD_REQUEST);
@@ -63,6 +68,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<?>> handlerHttpMessageNotReadableException(
             final HttpMessageNotReadableException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INVALID_HTTP_REQUEST, 400),
                 HttpStatus.BAD_REQUEST);
@@ -71,6 +77,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(ConstraintDefinitionException.class)
     protected ResponseEntity<ApiResponse<?>> handlerConstraintDefinitionException(
             final ConstraintDefinitionException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INVALID_HTTP_REQUEST, 400, ex.toString()),
                 HttpStatus.BAD_REQUEST);
@@ -79,6 +86,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<?>> handlerHttpRequestMethodNotSupportedException(
             final HttpRequestMethodNotSupportedException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.METHOD_NOT_ALLOWED, 405),
                 HttpStatus.METHOD_NOT_ALLOWED);
@@ -88,6 +96,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(
             final Exception ex, final HttpServletRequest request) throws IOException {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INTERNAL_SERVER, 500),
                 HttpStatus.INTERNAL_SERVER_ERROR);
@@ -96,6 +105,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handlerIllegalArgumentException(
             final IllegalArgumentException ex, final HttpServletRequest request) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INTERNAL_SERVER, 500),
                 HttpStatus.INTERNAL_SERVER_ERROR);
@@ -104,6 +114,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(IOException.class)
     public ResponseEntity<ApiResponse<?>> handlerIoException(
             final IOException ex, final HttpServletRequest request) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INTERNAL_SERVER, 500),
                 HttpStatus.INTERNAL_SERVER_ERROR);
@@ -112,6 +123,7 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<?>> handlerRuntimeException(
             final RuntimeException ex, final HttpServletRequest request) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.INTERNAL_SERVER, 500),
                 HttpStatus.INTERNAL_SERVER_ERROR);
@@ -120,6 +132,7 @@ public class GlobalExceptionAdvice {
     /** CUSTOM */
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ApiResponse<?>> handleCustomException(BaseException ex) {
+        log.error(ex.getMessage());
         return new ResponseEntity<>(ApiResponse.fail(ex), ex.getHttpStatus());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/config/AWSS3Config.java
+++ b/module-presentation/src/main/java/com/depromeet/config/AWSS3Config.java
@@ -1,31 +1,24 @@
 package com.depromeet.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
+@RequiredArgsConstructor
 public class AWSS3Config {
+    private final AwsS3Properties awsProperties;
 
-    /*
-     * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
-     *
-     * aws accessKey와 secretKey를 application.yml에 올리는 것은 알다시피 위험한 행동이다.
-     * 물론 IAM한테 적절한 권한을 주면 피해를 최소화 할 수 있으나 application.yml에 올리지 않고도 하는 방법이 있다.
-     * DefaultAwsRegionProviderChain 라는 것이 있는데 이는 아래의 4가지 체인을 돌면서 accessKey, secretKey 정보를 얻는다.
-     * 1. os 환경변수의 accessKey, SecretKey
-     * 2. java system 속성의 aws.accessKeyId, aws.secretKey 확인
-     * 3. /.aws/credentials 파일의 정보를 가져온다.
-     * 4. ec2의 역할을 가져와 인증(ec2에 s3 관련 역할이 있어야 함)
-     *
-     * 4번이 가장 안전하겠으나...우리는 NCP를 사용하므로 1번 방법을 사용하겠다.
-     * */
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .credentialsProvider(
+                        () ->
+                                AwsBasicCredentials.create(
+                                        awsProperties.accessKey(), awsProperties.secretKey()))
                 .region(Region.AP_NORTHEAST_2)
                 .build();
     }

--- a/module-presentation/src/main/java/com/depromeet/config/AWSS3Config.java
+++ b/module-presentation/src/main/java/com/depromeet/config/AWSS3Config.java
@@ -1,0 +1,32 @@
+package com.depromeet.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AWSS3Config {
+
+    /*
+     * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html
+     *
+     * aws accessKey와 secretKey를 application.yml에 올리는 것은 알다시피 위험한 행동이다.
+     * 물론 IAM한테 적절한 권한을 주면 피해를 최소화 할 수 있으나 application.yml에 올리지 않고도 하는 방법이 있다.
+     * DefaultAwsRegionProviderChain 라는 것이 있는데 이는 아래의 4가지 체인을 돌면서 accessKey, secretKey 정보를 얻는다.
+     * 1. os 환경변수의 accessKey, SecretKey
+     * 2. java system 속성의 aws.accessKeyId, aws.secretKey 확인
+     * 3. /.aws/credentials 파일의 정보를 가져온다.
+     * 4. ec2의 역할을 가져와 인증(ec2에 s3 관련 역할이 있어야 함)
+     *
+     * 4번이 가장 안전하겠으나...우리는 NCP를 사용하므로 1번 방법을 사용하겠다.
+     * */
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/config/AwsS3Properties.java
+++ b/module-presentation/src/main/java/com/depromeet/config/AwsS3Properties.java
@@ -1,0 +1,6 @@
+package com.depromeet.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.cloud.aws.credentials")
+public record AwsS3Properties(String accessKey, String secretKey) {}

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -1,0 +1,74 @@
+package com.depromeet.image.api;
+
+import static com.depromeet.type.image.ImageSuccessType.DELETE_IMAGES_SUCCESS;
+import static com.depromeet.type.image.ImageSuccessType.UPLOAD_IMAGES_SUCCESS;
+
+import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.image.dto.request.ImagesMemoryIdDto;
+import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.service.ImageDeleteService;
+import com.depromeet.image.service.ImageGetService;
+import com.depromeet.image.service.ImageUpdateService;
+import com.depromeet.image.service.ImageUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "이미지(images)")
+@RestController
+@RequestMapping("/api/v1/image")
+@RequiredArgsConstructor
+public class ImageController {
+    private final ImageUploadService imageUploadService;
+    private final ImageUpdateService imageUpdateService;
+    private final ImageGetService imageGetService;
+    private final ImageDeleteService imageDeleteService;
+
+    @Operation(summary = "Upload images to s3", description = "수영 기록 이미지 s3로 업로드")
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> uploadImages(@RequestPart List<MultipartFile> images) {
+        List<Long> imageIds = imageUploadService.uploadMemoryImages(images);
+
+        return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS, imageIds));
+    }
+
+    @Operation(summary = "Add memoryId to uploded images", description = "업로드 된 이미지에 memoryId 추가")
+    @PatchMapping("/memoryId")
+    public ResponseEntity<ApiResponse<?>> addMemoryToImages(
+            @RequestBody ImagesMemoryIdDto imagesMemoryIdDto) {
+        imageUploadService.addMemoryIdToImages(imagesMemoryIdDto);
+
+        return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS));
+    }
+
+    @Operation(summary = "update images", description = "수영 기록의 이미지 수정")
+    @PatchMapping
+    public ResponseEntity<ApiResponse<?>> updateImages(
+            @PathVariable(name = "memoryId") Long memoryId,
+            @RequestPart List<MultipartFile> images) {
+        imageUpdateService.updateImages(memoryId, images);
+
+        return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS));
+    }
+
+    @GetMapping("/{memoryId}")
+    public ResponseEntity<ApiResponse<?>> findImages(
+            @PathVariable(name = "memoryId") Long memoryId) {
+        List<MemoryImagesDto> memoryImages = imageGetService.findImagesByMemoryId(memoryId);
+
+        return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS, memoryImages));
+    }
+
+    @Operation(summary = "Delete images belongs to memory", description = "수영 기록의 이미지 삭제")
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<?>> deleteImages(
+            @PathVariable(value = "memoryId") Long memoryId) {
+        imageDeleteService.deleteAllImagesByMemoryId(memoryId);
+
+        return ResponseEntity.ok(ApiResponse.success(DELETE_IMAGES_SUCCESS));
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -28,7 +28,7 @@ public class ImageController {
     private final ImageGetService imageGetService;
     private final ImageDeleteService imageDeleteService;
 
-    @Operation(summary = "Upload images to s3", description = "수영 기록 이미지 s3로 업로드")
+    @Operation(summary = "수영 기록 이미지 s3에 업로드")
     @PostMapping
     public ResponseEntity<ApiResponse<?>> uploadImages(@RequestPart List<MultipartFile> images) {
         List<Long> imageIds = imageUploadService.uploadMemoryImages(images);
@@ -36,28 +36,30 @@ public class ImageController {
         return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS, imageIds));
     }
 
-    @Operation(summary = "Add memoryId to uploded images", description = "업로드 된 이미지에 memoryId 추가")
-    @PatchMapping("/memoryId")
+    @Operation(summary = "업로드 된 이미지에 memoryId 추가")
+    @PatchMapping("/memory") // 임시로 작성하긴 했는데 직관적이지 않네요 api 작명 추천 받습니다.
     public ResponseEntity<ApiResponse<?>> addMemoryToImages(
+            @RequestParam(name = "memoryId") Long memoryId,
             @RequestBody ImagesMemoryIdDto imagesMemoryIdDto) {
-        imageUploadService.addMemoryIdToImages(imagesMemoryIdDto);
+        imageUploadService.addMemoryIdToImages(memoryId, imagesMemoryIdDto);
 
         return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS));
     }
 
-    @Operation(summary = "update images", description = "수영 기록의 이미지 수정")
+    @Operation(summary = "수영 기록의 이미지 수정")
     @PatchMapping
     public ResponseEntity<ApiResponse<?>> updateImages(
-            @PathVariable(name = "memoryId") Long memoryId,
+            @RequestParam(name = "memoryId") Long memoryId,
             @RequestPart List<MultipartFile> images) {
         imageUpdateService.updateImages(memoryId, images);
 
         return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS));
     }
 
-    @GetMapping("/{memoryId}")
+    @Operation(summary = "수영 기록의 이미지 조회")
+    @GetMapping
     public ResponseEntity<ApiResponse<?>> findImages(
-            @PathVariable(name = "memoryId") Long memoryId) {
+            @RequestParam(name = "memoryId") Long memoryId) {
         List<MemoryImagesDto> memoryImages = imageGetService.findImagesByMemoryId(memoryId);
 
         return ResponseEntity.ok(ApiResponse.success(UPLOAD_IMAGES_SUCCESS, memoryImages));
@@ -66,7 +68,7 @@ public class ImageController {
     @Operation(summary = "Delete images belongs to memory", description = "수영 기록의 이미지 삭제")
     @DeleteMapping
     public ResponseEntity<ApiResponse<?>> deleteImages(
-            @PathVariable(value = "memoryId") Long memoryId) {
+            @RequestParam(value = "memoryId") Long memoryId) {
         imageDeleteService.deleteAllImagesByMemoryId(memoryId);
 
         return ResponseEntity.ok(ApiResponse.success(DELETE_IMAGES_SUCCESS));

--- a/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageUpdateDto.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageUpdateDto.java
@@ -1,0 +1,6 @@
+package com.depromeet.image.dto.request;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ImageUpdateDto(List<MultipartFile> images) {}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageUploadDto.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageUploadDto.java
@@ -1,0 +1,6 @@
+package com.depromeet.image.dto.request;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ImageUploadDto(List<MultipartFile> images) {}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/request/ImagesMemoryIdDto.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/request/ImagesMemoryIdDto.java
@@ -1,0 +1,5 @@
+package com.depromeet.image.dto.request;
+
+import java.util.List;
+
+public record ImagesMemoryIdDto(Long memoryId, List<Long> imageIds) {}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/request/ImagesMemoryIdDto.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/request/ImagesMemoryIdDto.java
@@ -1,5 +1,7 @@
 package com.depromeet.image.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record ImagesMemoryIdDto(Long memoryId, List<Long> imageIds) {}
+@Schema(name = "Image에 memory 할당")
+public record ImagesMemoryIdDto(@Schema(name = "Image PK List") List<Long> imageIds) {}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesDto.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesDto.java
@@ -1,0 +1,8 @@
+package com.depromeet.image.dto.response;
+
+import lombok.Builder;
+
+public record MemoryImagesDto(Long id, String imageName, String url) {
+    @Builder
+    public MemoryImagesDto {}
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteService.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteService.java
@@ -1,0 +1,7 @@
+package com.depromeet.image.service;
+
+public interface ImageDeleteService {
+    void deleteImage(Long imageId);
+
+    void deleteAllImagesByMemoryId(Long memoryId);
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
@@ -29,6 +29,7 @@ public class ImageDeleteServiceImpl implements ImageDeleteService {
                         .orElseThrow(() -> new NoSuchElementException("Image not found"));
 
         deleteImageFromS3(image);
+        imageRepository.deleteById(imageId);
     }
 
     @Override
@@ -38,6 +39,7 @@ public class ImageDeleteServiceImpl implements ImageDeleteService {
         for (Image image : images) {
             deleteImageFromS3(image);
         }
+        imageRepository.deleteAllByMemoryId(memoryId);
     }
 
     private void deleteImageFromS3(Image image) {

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
@@ -1,9 +1,11 @@
 package com.depromeet.image.service;
 
+import static com.depromeet.type.image.ImageErrorType.NOT_FOUND;
+
+import com.depromeet.exception.NotFoundException;
 import com.depromeet.image.Image;
 import com.depromeet.image.repository.ImageRepository;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -26,7 +28,7 @@ public class ImageDeleteServiceImpl implements ImageDeleteService {
         Image image =
                 imageRepository
                         .findById(imageId)
-                        .orElseThrow(() -> new NoSuchElementException("Image not found"));
+                        .orElseThrow(() -> new NotFoundException(NOT_FOUND));
 
         deleteImageFromS3(image);
         imageRepository.deleteById(imageId);
@@ -44,10 +46,7 @@ public class ImageDeleteServiceImpl implements ImageDeleteService {
 
     private void deleteImageFromS3(Image image) {
         DeleteObjectRequest deleteObjectRequest =
-                DeleteObjectRequest.builder()
-                        .bucket(bucketName)
-                        .key(image.getImageUrl()) // Todo: 수정 필요
-                        .build();
+                DeleteObjectRequest.builder().bucket(bucketName).key(image.getImageName()).build();
 
         s3Client.deleteObject(deleteObjectRequest);
     }

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
@@ -1,10 +1,9 @@
 package com.depromeet.image.service;
 
-import static com.depromeet.type.image.ImageErrorType.NOT_FOUND;
-
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.image.Image;
 import com.depromeet.image.repository.ImageRepository;
+import com.depromeet.type.image.ImageErrorType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,7 +27,7 @@ public class ImageDeleteServiceImpl implements ImageDeleteService {
         Image image =
                 imageRepository
                         .findById(imageId)
-                        .orElseThrow(() -> new NotFoundException(NOT_FOUND));
+                        .orElseThrow(() -> new NotFoundException(ImageErrorType.NOT_FOUND));
 
         deleteImageFromS3(image);
         imageRepository.deleteById(imageId);

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageDeleteServiceImpl.java
@@ -1,0 +1,52 @@
+package com.depromeet.image.service;
+
+import com.depromeet.image.Image;
+import com.depromeet.image.repository.ImageRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageDeleteServiceImpl implements ImageDeleteService {
+    private final ImageRepository imageRepository;
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public void deleteImage(Long imageId) {
+        Image image =
+                imageRepository
+                        .findById(imageId)
+                        .orElseThrow(() -> new NoSuchElementException("Image not found"));
+
+        deleteImageFromS3(image);
+    }
+
+    @Override
+    public void deleteAllImagesByMemoryId(Long memoryId) {
+        List<Image> images = imageRepository.findImagesByMemoryId(memoryId);
+
+        for (Image image : images) {
+            deleteImageFromS3(image);
+        }
+    }
+
+    private void deleteImageFromS3(Image image) {
+        DeleteObjectRequest deleteObjectRequest =
+                DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(image.getImageUrl()) // Todo: 수정 필요
+                        .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageGetService.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageGetService.java
@@ -1,0 +1,8 @@
+package com.depromeet.image.service;
+
+import com.depromeet.image.dto.response.MemoryImagesDto;
+import java.util.List;
+
+public interface ImageGetService {
+    List<MemoryImagesDto> findImagesByMemoryId(Long memoryId);
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageGetServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageGetServiceImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ImageGetServiceImpl implements ImageGetService {
     private final ImageRepository imageRepository;

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageGetServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageGetServiceImpl.java
@@ -1,0 +1,28 @@
+package com.depromeet.image.service;
+
+import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.repository.ImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageGetServiceImpl implements ImageGetService {
+    private final ImageRepository imageRepository;
+
+    @Override
+    public List<MemoryImagesDto> findImagesByMemoryId(Long memoryId) {
+        return imageRepository.findImagesByMemoryId(memoryId).stream()
+                .map(
+                        image ->
+                                MemoryImagesDto.builder()
+                                        .id(image.getId())
+                                        .imageName(image.getImageName())
+                                        .url(image.getImageUrl())
+                                        .build())
+                .toList();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateService.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateService.java
@@ -1,0 +1,8 @@
+package com.depromeet.image.service;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUpdateService {
+    void updateImages(Long memoryId, List<MultipartFile> images);
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
@@ -1,5 +1,9 @@
 package com.depromeet.image.service;
 
+import static com.depromeet.type.common.CommonErrorType.INTERNAL_SERVER;
+
+import com.depromeet.exception.InternalServerException;
+import com.depromeet.exception.NotFoundException;
 import com.depromeet.image.Image;
 import com.depromeet.image.repository.ImageRepository;
 import com.depromeet.memory.Memory;
@@ -8,8 +12,8 @@ import com.depromeet.util.ImageNameUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -41,7 +46,8 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
             List<String> updatedImageNames = updateNewImages(memoryId, images, existingImageNames);
             deleteNonUpdatedImages(existingImages, updatedImageNames);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            log.error(e.getMessage());
+            throw new InternalServerException(INTERNAL_SERVER);
         }
     }
 
@@ -75,7 +81,7 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
     private Memory getMemory(Long memoryId) {
         return memoryRepository
                 .findById(memoryId)
-                .orElseThrow(() -> new NoSuchElementException("Memory not found"));
+                .orElseThrow(() -> new NotFoundException(INTERNAL_SERVER)); // 임시
     }
 
     private String generateImageName(MultipartFile image) {

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
@@ -1,0 +1,112 @@
+package com.depromeet.image.service;
+
+import com.depromeet.image.Image;
+import com.depromeet.image.repository.ImageRepository;
+import com.depromeet.memory.Memory;
+import com.depromeet.memory.repository.MemoryRepository;
+import com.depromeet.util.ImageNameUtil;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageUpdateServiceImpl implements ImageUpdateService {
+    private final ImageRepository imageRepository;
+    private final MemoryRepository memoryRepository;
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public void updateImages(Long memoryId, List<MultipartFile> images) {
+        try {
+            List<Image> existingImages = imageRepository.findImagesByMemoryId(memoryId);
+            List<String> existingImageNames = getExistingImageNames(existingImages);
+
+            List<String> updatedImageNames = updateNewImages(memoryId, images, existingImageNames);
+            deleteNonUpdatedImages(existingImages, updatedImageNames);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<String> getExistingImageNames(List<Image> existingImages) {
+        return existingImages.stream().map(Image::getImageName).toList();
+    }
+
+    private List<String> updateNewImages(
+            Long memoryId, List<MultipartFile> images, List<String> existImagesName)
+            throws IOException {
+        Memory memory = getMemory(memoryId);
+        List<String> updatedImageNames = new ArrayList<>();
+
+        for (MultipartFile image : images) {
+            String imageName = generateImageName(image);
+            if (existImagesName.contains(imageName)) continue;
+
+            String imageUrl = upload(imageName, image);
+            saveNewImage(imageName, imageUrl, memory);
+
+            updatedImageNames.add(imageName);
+        }
+        return updatedImageNames;
+    }
+
+    private Memory getMemory(Long memoryId) {
+        return memoryRepository
+                .findById(memoryId)
+                .orElseThrow(() -> new NoSuchElementException("Memory not found"));
+    }
+
+    private String generateImageName(MultipartFile image) {
+        return ImageNameUtil.createImageName(
+                image.getOriginalFilename(), image.getContentType(), image.getSize());
+    }
+
+    private void saveNewImage(String imageName, String imageUrl, Memory memory) {
+        Image newImage =
+                Image.builder().imageName(imageName).imageUrl(imageUrl).memory(memory).build();
+        imageRepository.save(newImage);
+    }
+
+    private String upload(String imageName, MultipartFile image) throws IOException {
+        PutObjectRequest putObjectRequest =
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .contentType(image.getContentType())
+                        .contentLength(image.getSize())
+                        .key(imageName)
+                        .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+
+        s3Client.putObject(putObjectRequest, requestBody);
+
+        GetUrlRequest getUrlRequest =
+                GetUrlRequest.builder().bucket(bucketName).key(imageName).build();
+        return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+
+    private void deleteNonUpdatedImages(List<Image> existImages, List<String> updatedImageNames) {
+        List<Long> deletedImageIds =
+                existImages.stream()
+                        .filter(i -> !updatedImageNames.contains(i.getImageName()))
+                        .map(Image::getId)
+                        .toList();
+        if (!deletedImageIds.isEmpty()) {
+            imageRepository.deleteAllByIds(deletedImageIds);
+        }
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
@@ -37,12 +37,9 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
 
     public void updateImages(Long memoryId, List<MultipartFile> images) {
         try {
-            // 기존의 이미지
             List<Image> existingImages = imageRepository.findImagesByMemoryId(memoryId);
-            // 기존 이미지의 이미지 이름 리스트
             List<String> existingImageNames = getExistingImageNames(existingImages);
 
-            // 새로 들어온 이미지 이름 리스트
             List<String> updatedImageNames = updateNewImages(memoryId, images, existingImageNames);
             deleteNonUpdatedImages(existingImages, updatedImageNames);
         } catch (IOException e) {
@@ -63,15 +60,11 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
         List<String> updatedImageNames = new ArrayList<>();
 
         for (MultipartFile image : images) {
-            // 새로운 이미지의 이름 생성
             String imageName = generateImageName(image);
-            // 새로운 이미지의 이름 리스트에 추가
             updatedImageNames.add(imageName);
 
-            // 만약 기존의 이미지 리스트에 새로운 이미지 이름 존재시 넘어감
             if (existImagesName.contains(imageName)) continue;
 
-            // 만약 없다면 s3에 업로드 후 저장
             String imageUrl = upload(imageName, image);
             saveNewImage(imageName, imageUrl, memory);
         }

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
@@ -32,9 +32,12 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
 
     public void updateImages(Long memoryId, List<MultipartFile> images) {
         try {
+            // 기존의 이미지
             List<Image> existingImages = imageRepository.findImagesByMemoryId(memoryId);
+            // 기존 이미지의 이미지 이름 리스트
             List<String> existingImageNames = getExistingImageNames(existingImages);
 
+            // 새로 들어온 이미지 이름 리스트
             List<String> updatedImageNames = updateNewImages(memoryId, images, existingImageNames);
             deleteNonUpdatedImages(existingImages, updatedImageNames);
         } catch (IOException e) {
@@ -49,17 +52,22 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
     private List<String> updateNewImages(
             Long memoryId, List<MultipartFile> images, List<String> existImagesName)
             throws IOException {
+
         Memory memory = getMemory(memoryId);
         List<String> updatedImageNames = new ArrayList<>();
 
         for (MultipartFile image : images) {
+            // 새로운 이미지의 이름 생성
             String imageName = generateImageName(image);
+            // 새로운 이미지의 이름 리스트에 추가
+            updatedImageNames.add(imageName);
+
+            // 만약 기존의 이미지 리스트에 새로운 이미지 이름 존재시 넘어감
             if (existImagesName.contains(imageName)) continue;
 
+            // 만약 없다면 s3에 업로드 후 저장
             String imageUrl = upload(imageName, image);
             saveNewImage(imageName, imageUrl, memory);
-
-            updatedImageNames.add(imageName);
         }
         return updatedImageNames;
     }

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadService.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadService.java
@@ -7,5 +7,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageUploadService {
     List<Long> uploadMemoryImages(List<MultipartFile> files);
 
-    void addMemoryIdToImages(ImagesMemoryIdDto inputImagesMemoryIdDto);
+    void addMemoryIdToImages(Long memoryId, ImagesMemoryIdDto inputImagesMemoryIdDto);
 }

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadService.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadService.java
@@ -1,0 +1,11 @@
+package com.depromeet.image.service;
+
+import com.depromeet.image.dto.request.ImagesMemoryIdDto;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploadService {
+    List<Long> uploadMemoryImages(List<MultipartFile> files);
+
+    void addMemoryIdToImages(ImagesMemoryIdDto inputImagesMemoryIdDto);
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
@@ -62,7 +62,6 @@ public class ImageUploadServiceImpl implements ImageUploadService {
         List<Image> images = new ArrayList<>();
         try {
             for (MultipartFile multipartFile : memoryImages) {
-
                 String originalImageName = multipartFile.getOriginalFilename();
                 String contentType = multipartFile.getContentType();
                 long imageSize = multipartFile.getSize();

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
@@ -32,17 +32,14 @@ public class ImageUploadServiceImpl implements ImageUploadService {
     private String bucketName;
 
     @Override
-    public List<Long> uploadMemoryImages(List<MultipartFile> files) {
-        //        List<MultipartFile> memoryImages = imageUploadDto.images();
-        List<MultipartFile> memoryImages = files; // 임시
+    public List<Long> uploadMemoryImages(List<MultipartFile> memoryImages) {
         List<Image> images = uploadImagesAndGetImages(memoryImages);
 
         return imageRepository.saveAll(images);
     }
 
     @Override
-    public void addMemoryIdToImages(ImagesMemoryIdDto inputImagesMemoryIdDto) {
-        Long memoryId = inputImagesMemoryIdDto.memoryId();
+    public void addMemoryIdToImages(Long memoryId, ImagesMemoryIdDto inputImagesMemoryIdDto) {
         Memory memory =
                 memoryRepository
                         .findById(memoryId)

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
@@ -1,0 +1,105 @@
+package com.depromeet.image.service;
+
+import com.depromeet.image.Image;
+import com.depromeet.image.dto.request.ImagesMemoryIdDto;
+import com.depromeet.image.repository.ImageRepository;
+import com.depromeet.memory.Memory;
+import com.depromeet.memory.repository.MemoryRepository;
+import com.depromeet.util.ImageNameUtil;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageUploadServiceImpl implements ImageUploadService {
+    private final ImageRepository imageRepository;
+    private final MemoryRepository memoryRepository;
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public List<Long> uploadMemoryImages(List<MultipartFile> files) {
+        //        List<MultipartFile> memoryImages = imageUploadDto.images();
+        List<MultipartFile> memoryImages = files; // 임시
+        List<Image> images = uploadImagesAndGetImages(memoryImages);
+
+        return imageRepository.saveAll(images);
+    }
+
+    @Override
+    public void addMemoryIdToImages(ImagesMemoryIdDto inputImagesMemoryIdDto) {
+        Long memoryId = inputImagesMemoryIdDto.memoryId();
+        Memory memory =
+                memoryRepository
+                        .findById(memoryId)
+                        .orElseThrow(() -> new NoSuchElementException("Memory not found"));
+        List<Long> imageIds = inputImagesMemoryIdDto.imageIds();
+
+        List<Image> images = imageRepository.findImageByIds(imageIds);
+        for (Image image : images) {
+            image.addMemoryToImage(memory);
+        }
+        imageRepository.saveAll(images);
+    }
+
+    private List<Image> uploadImagesAndGetImages(List<MultipartFile> memoryImages) {
+        List<Image> images = new ArrayList<>();
+        try {
+            for (MultipartFile multipartFile : memoryImages) {
+
+                String originalImageName = multipartFile.getOriginalFilename();
+                String contentType = multipartFile.getContentType();
+                long imageSize = multipartFile.getSize();
+
+                String imageName =
+                        ImageNameUtil.createImageName(originalImageName, contentType, imageSize);
+                uploadImage(multipartFile, contentType, imageSize, imageName);
+
+                String imageUrl = getImageUrl(imageName);
+
+                Image image = Image.builder().imageName(imageName).imageUrl(imageUrl).build();
+                images.add(image);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return images;
+    }
+
+    private void uploadImage(
+            MultipartFile multipartFile, String contentType, long imageSize, String imageName)
+            throws IOException {
+        PutObjectRequest putObjectRequest =
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .contentType(contentType)
+                        .contentLength(imageSize)
+                        .key(imageName)
+                        .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(multipartFile.getBytes());
+
+        s3Client.putObject(putObjectRequest, requestBody);
+    }
+
+    private String getImageUrl(String imageName) {
+        GetUrlRequest getUrlRequest =
+                GetUrlRequest.builder().bucket(bucketName).key(imageName).build();
+
+        return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUploadServiceImpl.java
@@ -1,5 +1,8 @@
 package com.depromeet.image.service;
 
+import static com.depromeet.type.common.CommonErrorType.INTERNAL_SERVER;
+
+import com.depromeet.exception.InternalServerException;
 import com.depromeet.image.Image;
 import com.depromeet.image.dto.request.ImagesMemoryIdDto;
 import com.depromeet.image.repository.ImageRepository;
@@ -11,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -72,7 +77,8 @@ public class ImageUploadServiceImpl implements ImageUploadService {
                 images.add(image);
             }
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            log.error(e.getMessage());
+            throw new InternalServerException(INTERNAL_SERVER);
         }
         return images;
     }

--- a/module-presentation/src/main/java/com/depromeet/security/filter/JwtAuthenticationFilter.java
+++ b/module-presentation/src/main/java/com/depromeet/security/filter/JwtAuthenticationFilter.java
@@ -101,6 +101,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || url.startsWith("/favicon.ico")
                 || url.startsWith("/oauth2")
                 || url.startsWith("/login")
+                || url.startsWith("/depromeet-actuator")
                 || url.startsWith("/api/v1/auth");
     }
 

--- a/module-presentation/src/main/java/com/depromeet/security/oauth/handler/OAuth2FailureHandler.java
+++ b/module-presentation/src/main/java/com/depromeet/security/oauth/handler/OAuth2FailureHandler.java
@@ -23,6 +23,5 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
         log.error(exception.getMessage());
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.sendRedirect("http://localhost:3000/");
     }
 }

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -17,6 +17,9 @@ spring:
       max-request-size: 20MB
   cloud:
     aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
       s3:
         bucket: ${AWS_BUCKET}
 

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -10,6 +10,15 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 5MB
+      max-request-size: 20MB
+  cloud:
+    aws:
+      s3:
+        bucket: ${AWS_BUCKET}
 
 
 swagger.version: "v0.1"

--- a/module-presentation/src/main/resources/application-security.yml
+++ b/module-presentation/src/main/resources/application-security.yml
@@ -13,7 +13,7 @@ spring:
             redirect-uri: ${KAKAO_REDIRECT_URL}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
-            client-name: Kakao
+            client-name: kakao
             scope:
               - profile_nickname
               - account_email


### PR DESCRIPTION
## 🌱 관련 이슈

- close #30 

## 📌 작업 내용 및 특이사항
- aws s3 dependencies는 io.awspring.cloud:spring-cloud-aws-starter를 사용하였습니다. 
  - aws s3 dependencies에는 크게 AWS에서 제공하는 aws-sdk-java와 io.awspring.cloud가 있는데 그 중 스프링 기반 모듈과 통합된 io.awspring.cloud를 사용하였습니다. (https://docs.awspring.io/spring-cloud-aws/docs/3.1.0/reference/html/index.html#configuring-credentials)
- s3Config 설정을 하였습니다. 
  - s3Config에는 큰 기능은 없고 accessKey, secretKey, region값을 설정하는 기능인데, 이때 EnvironmentVariableCredentialsProvider로 OS환경변수에 설정된 accessKey, secretKey값을 자동으로 읽을 수 있도록 하여 application.yml에 값을 넣지 않을 수 있게 설정하였습니다.
- Image 도메인에 imageName 칼럼을 추가하였습니다. 이미지 수정 로직에서 기존의 이미지와 비교시 이미지 이름을 기준으로 비교를 하고있어 추가를 하게 되었습니다. 
- 이미지 업로드/수정/조회/삭제 기능에 대해 각각 Service를 만들었습니다. 분리를 할까말까 생각을 많이 했는데 생각보다 코드량이 많아져서(!) 분리를 했습니다.
- Image 도메인과 Memory Domain이 의존관계이다 보니 memoryRepository를 ImageService에 DI 시켜야 했습니다. service 내부에 사용한 코드는 memoryRepository.findById(id) 만 사용하였으나 컨플릭트가 날 수 있으니 참고하시면 되겠습니다. 추가적으로 memory 관련 ErrorType를 생성하지 않고 기존의 CommonErrorType를 임시로 사용하였습니다. 
- 현재 S3 업로드, 삭제까지는 잘 작동이 되나 이미지 URL 조회시 403에러가 뜨고 있습니다. 이는 AWS S3 권한 문제라 빨리 고치도록 하겠습니다. 

## 📝 참고사항
aws accessKey, secretKey 같은 경우 OS 환경변수 설정에 추가하시면 되고 **절대 어디 노출시키면 안됩니다** 