### PR TITLE
fix: CORS 정책 수정 및 Swagger 추가

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/config/SwaggerConfig.java
+++ b/module-presentation/src/main/java/com/depromeet/config/SwaggerConfig.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,10 +35,19 @@ public class SwaggerConfig {
 
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("Bearer Token");
 
+        Server productionServer = new Server();
+        productionServer.setDescription("Production Server");
+        productionServer.setUrl("https://appu.o-r.kr");
+
+        Server localServer = new Server();
+        localServer.setDescription("Local Server");
+        localServer.setUrl("http://localhost:8080");
+
         return new OpenAPI()
                 .info(info)
                 .addSecurityItem(getSecurityRequirement())
                 .components(getAuthComponent())
+                .servers(List.of(productionServer, localServer))
                 .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
                 .addSecurityItem(securityRequirement);
     }

--- a/module-presentation/src/main/java/com/depromeet/security/SecurityConfig.java
+++ b/module-presentation/src/main/java/com/depromeet/security/SecurityConfig.java
@@ -91,7 +91,9 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://appu.o-r.kr"));
-        configuration.setAllowedMethods(List.of("*"));
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.addExposedHeader("Authorization");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #67 

## 📌 작업 내용 및 특이사항
- SecurityConfig의 CorsConfigurationSource의 AllowedHeader와 AllowedMethod를 추가하였습니다. 또한 Authorization 헤더를 노출시켰습니다.
- Swagger의 원격 서버 주소를 추가하였습니다.

## 📝 참고사항
-