### PR TITLE
fix: image controller 오류 수정

### DIFF
--- a/module-independent/src/main/java/com/depromeet/type/image/ImageSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/image/ImageSuccessType.java
@@ -6,7 +6,8 @@ public enum ImageSuccessType implements SuccessType {
     UPLOAD_IMAGES_SUCCESS("IMAGE_1", "이미지 업로드에 성공하였습니다"),
     ADD_MEMORY_TO_IMAGES_SUCCESS("IMAGE_2", "이미지에 memory를 추가하는데 성공하였습니다"),
     UPDATE_IMAGES_SUCCESS("IMAGE_3", "이미지 수정에 성공하였습니다"),
-    GET_IMAGES_SUCCESS("IMAGE_4", "이미지 조회에 성공하였습니다");
+    GET_IMAGES_SUCCESS("IMAGE_4", "이미지 조회에 성공하였습니다"),
+    DELETE_IMAGE_SUCCESS("IMAGE_5", "이미지 삭제에 성공하였습니다");
 
     private final String code;
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageJpaRepository.java
@@ -4,6 +4,7 @@ import com.depromeet.image.entity.ImageEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ImageJpaRepository extends JpaRepository<ImageEntity, Long> {
     List<ImageEntity> findByMemoryId(Long memoryId);
@@ -11,7 +12,7 @@ public interface ImageJpaRepository extends JpaRepository<ImageEntity, Long> {
     @Query(value = """
     select i from ImageEntity i where i.id in :ids
     """)
-    List<ImageEntity> findAllByIds(List<Long> ids);
+    List<ImageEntity> findAllByIds(@Param("ids") List<Long> ids);
 
     void deleteAllByMemoryId(Long memoryId);
 }

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
@@ -1,27 +1,29 @@
 package com.depromeet.image.api;
 
 import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.image.dto.response.MemoryImagesDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "이미지(images)")
 public interface ImageApi {
     @Operation(summary = "수영 기록 이미지 업로드")
-    ApiResponse<?> uploadImages(@RequestPart @NotNull List<MultipartFile> images);
+    ApiResponse<List<Long>> uploadImages(
+            @RequestPart(value = "images") @NotNull List<MultipartFile> images);
 
     @Operation(summary = "수영 기록 이미지 수정")
     ApiResponse<?> updateImages(
-            @RequestParam("memoryId") Long memoryId, @RequestPart List<MultipartFile> images);
+            @PathVariable("memoryId") Long memoryId,
+            @RequestPart(value = "images") List<MultipartFile> images);
 
     @Operation(summary = "수영 기록의 이미지 조회")
-    ApiResponse<?> findImages(@RequestParam(name = "memoryId") Long memoryId);
+    ApiResponse<List<MemoryImagesDto>> findImages(@PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "Delete images belongs to memory", description = "수영 기록의 이미지 삭제")
-    ResponseEntity<?> deleteImages(@RequestParam(value = "memoryId") Long memoryId);
+    ApiResponse<?> deleteImages(@PathVariable("memoryId") Long memoryId);
 }

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
@@ -14,12 +14,12 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageApi {
     @Operation(summary = "수영 기록 이미지 업로드")
     ApiResponse<List<Long>> uploadImages(
-            @RequestPart(value = "images") @NotNull List<MultipartFile> images);
+            @RequestPart("images") @NotNull List<MultipartFile> images);
 
     @Operation(summary = "수영 기록 이미지 수정")
     ApiResponse<?> updateImages(
             @PathVariable("memoryId") Long memoryId,
-            @RequestPart(value = "images") List<MultipartFile> images);
+            @RequestPart("images") List<MultipartFile> images);
 
     @Operation(summary = "수영 기록의 이미지 조회")
     ApiResponse<List<MemoryImagesDto>> findImages(@PathVariable("memoryId") Long memoryId);

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -11,7 +11,6 @@ import com.depromeet.image.service.ImageUploadService;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,7 +24,7 @@ public class ImageController implements ImageApi {
     private final ImageDeleteService imageDeleteService;
 
     @PostMapping
-    public ApiResponse<?> uploadImages(
+    public ApiResponse<List<Long>> uploadImages(
             @RequestPart(value = "images") @NotNull List<MultipartFile> images) {
         List<Long> imageIds = imageUploadService.uploadMemoryImages(images);
 
@@ -34,23 +33,24 @@ public class ImageController implements ImageApi {
 
     @PatchMapping("/memory/{memoryId}")
     public ApiResponse<?> updateImages(
-            @PathVariable Long memoryId, @RequestPart List<MultipartFile> images) {
+            @PathVariable("memoryId") Long memoryId,
+            @RequestPart(value = "images") List<MultipartFile> images) {
         imageUpdateService.updateImages(memoryId, images);
 
         return ApiResponse.success(UPDATE_IMAGES_SUCCESS);
     }
 
     @GetMapping("/memory/{memoryId}")
-    public ApiResponse<?> findImages(@PathVariable Long memoryId) {
+    public ApiResponse<List<MemoryImagesDto>> findImages(@PathVariable("memoryId") Long memoryId) {
         List<MemoryImagesDto> memoryImages = imageGetService.findImagesByMemoryId(memoryId);
 
         return ApiResponse.success(GET_IMAGES_SUCCESS, memoryImages);
     }
 
     @DeleteMapping("/memory/{memoryId}")
-    public ResponseEntity<?> deleteImages(@PathVariable Long memoryId) {
+    public ApiResponse<?> deleteImages(@PathVariable("memoryId") Long memoryId) {
         imageDeleteService.deleteAllImagesByMemoryId(memoryId);
 
-        return ResponseEntity.noContent().build();
+        return ApiResponse.success(DELETE_IMAGE_SUCCESS);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/image/service/ImageUpdateServiceImpl.java
@@ -10,6 +10,7 @@ import com.depromeet.image.repository.ImageRepository;
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.repository.MemoryRepository;
 import com.depromeet.type.image.ImageErrorType;
+import com.depromeet.type.memory.MemoryErrorType;
 import com.depromeet.util.ImageNameUtil;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
         for (MultipartFile image : images) {
             String originImageName = image.getOriginalFilename();
             String imageName = generateImageName(originImageName);
-            updatedImageNames.add(imageName); // 이게 if문 밑으로 내려가야 하지 않을까요?
+            updatedImageNames.add(imageName);
 
             if (existImagesName.contains(imageName)) continue;
 
@@ -79,7 +80,7 @@ public class ImageUpdateServiceImpl implements ImageUpdateService {
     private Memory getMemory(Long memoryId) {
         return memoryRepository
                 .findById(memoryId)
-                .orElseThrow(() -> new NotFoundException(INTERNAL_SERVER)); // 임시
+                .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND));
     }
 
     private String generateImageName(String originImageName) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #77

## 📌 작업 내용 및 특이사항
- 이미지 컨트롤러 오류를 수정합니다.
- 이미지 수정 시 JPQL 변수가 설정되지 않았습니다.
- `ImageApi` 인터페이스 및 `ImageController`에서 `PathVariable`이 정확히 적용되지 않았습니다.

## 📝 참고사항
- 이미지 업로드
<img width="854" alt="Screenshot 2024-07-22 at 13 21 22" src="https://github.com/user-attachments/assets/ade17486-86f6-41a9-a544-63279491d9c3">

- 이미지 수정
<img width="838" alt="Screenshot 2024-07-22 at 13 20 59" src="https://github.com/user-attachments/assets/c4a70e92-cc17-4edf-b923-bec8534e080a">

- 이미지 조회
<img width="833" alt="Screenshot 2024-07-22 at 13 21 58" src="https://github.com/user-attachments/assets/969547b6-cb84-4c61-8b5d-154570f03592">

- 이미지 삭제
<img width="846" alt="Screenshot 2024-07-22 at 13 22 21" src="https://github.com/user-attachments/assets/dbae8c61-7c64-4aab-ad66-1095da81c578">
<img width="848" alt="Screenshot 2024-07-22 at 13 22 32" src="https://github.com/user-attachments/assets/22becb2a-045e-4102-8c08-2ea58e28dd4b">