### PR TITLE
feat: 캘린더 조회 API 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/Member.java
+++ b/module-domain/src/main/java/com/depromeet/member/Member.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 @Getter
 public class Member {
     private Long id;
-    private Long goal;
+    private Integer goal;
     private String name;
     private String email;
     private MemberRole role;
     private String refreshToken;
 
     @Builder
-    public Member(Long id, Long goal, String name, String email, MemberRole role) {
+    public Member(Long id, Integer goal, String name, String email, MemberRole role) {
         this.id = id;
         this.goal = goal;
         this.name = name;

--- a/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
@@ -9,7 +9,8 @@ public enum CommonErrorType implements ErrorType {
     INVALID_HTTP_REQUEST("COMMON_4", "허용되지 않는 문자열이 입력되었습니다"),
     METHOD_NOT_ALLOWED("COMMON_5", "잘못된 HTTP 메소드의 요청입니다"),
     INTERNAL_SERVER("COMMON_6", "알 수 없는 서버 에러가 발생했습니다"),
-    VALIDATION_FAILED("COMMON_7", "정상적이지 않은 입력값입니다");
+    VALIDATION_FAILED("COMMON_7", "정상적이지 않은 입력값입니다"),
+    BAD_REQUEST("COMMON_8", "잘못된 요청입니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
@@ -5,7 +5,8 @@ import com.depromeet.type.ErrorType;
 public enum MemoryErrorType implements ErrorType {
     CREATE_FAILED("MEMORY_1", "기록 저장에 실패하였습니다"),
     NOT_FOUND("MEMORY_2", "기록이 존재하지 않습니다"),
-    UPDATE_FAILED("MEMORY_3", "작성자가 아니라면 기록을 수정할 수 없습니다");
+    UPDATE_FAILED("MEMORY_3", "작성자가 아니라면 기록을 수정할 수 없습니다"),
+    FORBIDDEN("MEMORY_4", "메모리에 접근 권한이 없습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
@@ -6,7 +6,8 @@ public enum MemoryErrorType implements ErrorType {
     CREATE_FAILED("MEMORY_1", "기록 저장에 실패하였습니다"),
     NOT_FOUND("MEMORY_2", "기록이 존재하지 않습니다"),
     UPDATE_FAILED("MEMORY_3", "작성자가 아니라면 기록을 수정할 수 없습니다"),
-    FORBIDDEN("MEMORY_4", "메모리에 접근 권한이 없습니다");
+    FORBIDDEN("MEMORY_4", "메모리에 접근 권한이 없습니다"),
+    ALREADY_CREATED("MEMORY_5", "해당 날짜에 이미 기록이 존재합니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/memory/MemorySuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/memory/MemorySuccessType.java
@@ -6,7 +6,9 @@ public enum MemorySuccessType implements SuccessType {
     POST_RESULT_SUCCESS("MEMORY_1", "수영 기록 저장에 성공하였습니다"),
     GET_RESULT_SUCCESS("MEMORY_2", "수영 기록 조회에 성공하였습니다"),
     PATCH_RESULT_SUCCESS("MEMORY_3", "수영 기록 수정에 성공하였습니다"),
-    GET_TIMELINE_SUCCESS("MEMORY_4", "타임라인 조회에 성공하였습니다");
+    GET_TIMELINE_SUCCESS("MEMORY_4", "타임라인 조회에 성공하였습니다"),
+    GET_CALENDAR_SUCCESS("MEMORY_5", "캘린더 조회에 성공하였습니다");
+    ;
 
     private final String code;
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -47,6 +47,6 @@ public class MemberEntity {
     }
 
     public Member toModel() {
-        return Member.builder().id(id).name(name).email(email).role(role).build();
+        return Member.builder().id(id).name(name).email(email).role(role).goal(goal).build();
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -7,17 +7,15 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,7 +33,28 @@ public class MemberEntity {
 
     @Column private String refreshToken;
 
-    @Builder.Default private Integer goal = 1000;
+    private Integer goal;
+
+    @Builder
+    public MemberEntity(
+            Long id,
+            String name,
+            String email,
+            MemberRole role,
+            String refreshToken,
+            Integer goal) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+        this.refreshToken = refreshToken;
+        this.goal = goal;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.goal = 1000;
+    }
 
     public static MemberEntity from(Member member) {
         return builder()

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -8,15 +8,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Entity
+@Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -33,13 +35,7 @@ public class MemberEntity {
 
     @Column private String refreshToken;
 
-    @Builder
-    private MemberEntity(Long id, String name, String email, MemberRole role) {
-        this.id = id;
-        this.name = name;
-        this.email = email;
-        this.role = role;
-    }
+    @Builder.Default private Integer goal = 1000;
 
     public static MemberEntity from(Member member) {
         return builder()

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
@@ -1,13 +1,6 @@
 package com.depromeet.memory.repository;
 
 import com.depromeet.memory.entity.MemoryEntity;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {
-    @Query(
-            "select m from MemoryEntity m join fetch m.member join fetch m.memoryDetail join fetch m.pool join fetch m.strokes where m.id = :memoryId")
-    Optional<MemoryEntity> findById(@Param(value = "memoryId") Long memoryId);
-}
+public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
@@ -1,6 +1,13 @@
 package com.depromeet.memory.repository;
 
 import com.depromeet.memory.entity.MemoryEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {}
+public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {
+    @Query(
+            "select m from MemoryEntity m join fetch m.member join fetch m.memoryDetail join fetch m.pool join fetch m.strokes where m.id = :memoryId")
+    Optional<MemoryEntity> findById(@Param(value = "memoryId") Long memoryId);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
@@ -1,6 +1,10 @@
 package com.depromeet.memory.repository;
 
 import com.depromeet.memory.entity.MemoryEntity;
+import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {}
+public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {
+    Optional<MemoryEntity> findByRecordAt(LocalDate recordAt);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -2,6 +2,7 @@ package com.depromeet.memory.repository;
 
 import com.depromeet.memory.Memory;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,4 +30,6 @@ public interface MemoryRepository {
             LocalDate cursorRecordAt,
             Pageable pageable,
             LocalDate recordAt);
+
+    List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month);
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -12,6 +12,8 @@ public interface MemoryRepository {
 
     Optional<Memory> findById(Long memoryId);
 
+    Optional<Memory> findByRecordAt(LocalDate recordAt);
+
     Optional<Memory> update(Long memoryId, Memory memoryUpdate);
 
     Slice<Memory> getSliceMemoryByMemberIdAndCursorId(

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepositoryImpl.java
@@ -63,6 +63,15 @@ public class MemoryRepositoryImpl implements MemoryRepository {
     }
 
     @Override
+    public Optional<Memory> findByRecordAt(LocalDate recordAt) {
+        Optional<MemoryEntity> nullableMemoryEntity = memoryJpaRepository.findByRecordAt(recordAt);
+        if (nullableMemoryEntity.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(nullableMemoryEntity.get().toModel());
+    }
+
+    @Override
     public Optional<Memory> update(Long memoryId, Memory memoryUpdate) {
         return memoryJpaRepository
                 .findById(memoryId)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepositoryImpl.java
@@ -39,7 +39,27 @@ public class MemoryRepositoryImpl implements MemoryRepository {
 
     @Override
     public Optional<Memory> findById(Long memoryId) {
-        return memoryJpaRepository.findById(memoryId).map(MemoryEntity::toModel);
+        // select m from MemoryEntity m join fetch m.member join fetch m.memoryDetail join fetch
+        // m.pool join fetch m.strokes where m.id = :memoryId
+        MemoryEntity memoryEntity =
+                queryFactory
+                        .selectFrom(memory)
+                        .join(memory.member, memberEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.pool, poolEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.strokes, strokeEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.images, imageEntity)
+                        .where(memory.id.eq(memoryId))
+                        .fetchOne();
+
+        if (memoryEntity == null) {
+            return Optional.empty();
+        }
+        return Optional.of(memoryEntity.toModel());
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepositoryImpl.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepositoryImpl.java
@@ -1,11 +1,18 @@
 package com.depromeet.memory.repository;
 
+import static com.depromeet.image.entity.QImageEntity.*;
+import static com.depromeet.member.entity.QMemberEntity.*;
+import static com.depromeet.memory.entity.QMemoryDetailEntity.*;
+import static com.depromeet.memory.entity.QStrokeEntity.*;
+import static com.depromeet.pool.entity.QPoolEntity.*;
+
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.entity.MemoryEntity;
 import com.depromeet.memory.entity.QMemoryEntity;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -20,8 +27,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class MemoryRepositoryImpl implements MemoryRepository {
-    private final MemoryJpaRepository memoryJpaRepository;
     private final JPAQueryFactory queryFactory;
+    private final MemoryJpaRepository memoryJpaRepository;
 
     QMemoryEntity memory = QMemoryEntity.memoryEntity;
 
@@ -129,6 +136,27 @@ public class MemoryRepositoryImpl implements MemoryRepository {
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
+    @Override
+    public List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month) {
+        List<MemoryEntity> memories =
+                queryFactory
+                        .selectFrom(memory)
+                        .join(memory.member, memberEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.pool, poolEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.strokes, strokeEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.images, imageEntity)
+                        .where(memberEq(memberId), yearAndMonthEq(year, month))
+                        .orderBy(memory.recordAt.asc())
+                        .fetch();
+
+        return toModel(memories);
+    }
+
     private BooleanExpression ltCursorIdOrRecordAt(Long cursorId, LocalDate recordAt) {
         if (cursorId == null || recordAt == null) {
             return null;
@@ -146,10 +174,10 @@ public class MemoryRepositoryImpl implements MemoryRepository {
     }
 
     private BooleanExpression gtCursorId(Long cursorId) {
-        if (cursorId != null) {
-            return memory.id.gt(cursorId);
+        if (cursorId == null) {
+            return null;
         }
-        return null;
+        return memory.id.gt(cursorId);
     }
 
     private BooleanExpression goeRecordAt(LocalDate recordAt) {
@@ -157,6 +185,23 @@ public class MemoryRepositoryImpl implements MemoryRepository {
             return memory.recordAt.goe(recordAt);
         }
         return null;
+    }
+
+    private BooleanExpression memberEq(Long memberId) {
+        if (memberId == null) {
+            return null;
+        }
+        return memory.member.id.eq(memberId);
+    }
+
+    private BooleanExpression yearAndMonthEq(Integer year, Short month) {
+        if (year == null) {
+            return null;
+        }
+        YearMonth yearMonth = YearMonth.of(year, month);
+        int lastDay = yearMonth.lengthOfMonth();
+        return memory.recordAt.between(
+                LocalDate.of(year, month, 1), LocalDate.of(year, month, lastDay));
     }
 
     private List<Memory> toModel(List<MemoryEntity> memoryEntities) {

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/memory/repository/MemoryRepositoryTest.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/memory/repository/MemoryRepositoryTest.java
@@ -48,7 +48,7 @@ public class MemoryRepositoryTest {
         pageable = getPageable();
 
         memberRepositoryImpl = new MemberRepositoryImpl(memberJpaRepository);
-        memoryRepositoryImpl = new MemoryRepositoryImpl(memoryJpaRepository, queryFactory);
+        memoryRepositoryImpl = new MemoryRepositoryImpl(queryFactory, memoryJpaRepository);
         memoryDetailRepositoryImpl = new MemoryDetailRepositoryImpl(memoryDetailJpaRepository);
         member = memberRepositoryImpl.save(MemberFixture.mockMember());
         List<MemoryDetail> memoryDetailList = MemoryDetailFixture.memoryDetailList();

--- a/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
+++ b/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
@@ -88,7 +88,6 @@ public class GlobalExceptionAdvice {
     protected ResponseEntity<ApiResponse<?>> handlerConstraintViolationException(
             final ConstraintViolationException ex) {
         log.error(ex.getMessage());
-        log.error("여긴 왜 아니야?");
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.VALIDATION_FAILED, 400, ex.toString()),
                 HttpStatus.BAD_REQUEST);

--- a/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
+++ b/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
@@ -88,6 +88,7 @@ public class GlobalExceptionAdvice {
     protected ResponseEntity<ApiResponse<?>> handlerConstraintViolationException(
             final ConstraintViolationException ex) {
         log.error(ex.getMessage());
+        log.error("여긴 왜 아니야?");
         return new ResponseEntity<>(
                 ApiResponse.fail(CommonErrorType.VALIDATION_FAILED, 400, ex.toString()),
                 HttpStatus.BAD_REQUEST);
@@ -134,9 +135,11 @@ public class GlobalExceptionAdvice {
     public ResponseEntity<ApiResponse<?>> handlerRuntimeException(
             final RuntimeException ex, final HttpServletRequest request) {
         log.error(ex.getMessage());
-        return new ResponseEntity<>(
-                ApiResponse.fail(CommonErrorType.INTERNAL_SERVER, 500),
-                HttpStatus.INTERNAL_SERVER_ERROR);
+        String[] message = ex.getMessage().split(" ");
+        int code = Integer.parseInt(message[0]);
+        HttpStatus httpStatus = HttpStatus.resolve(code);
+        CommonErrorType errorType = CommonErrorType.valueOf(message[1]);
+        return new ResponseEntity<>(ApiResponse.fail(errorType, code), httpStatus);
     }
 
     /** CUSTOM */

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSimpleResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSimpleResponse.java
@@ -1,3 +1,3 @@
 package com.depromeet.member.dto.response;
 
-public record MemberSimpleResponse(Long goal, String name) {}
+public record MemberSimpleResponse(Integer goal, String name) {}

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -3,11 +3,14 @@ package com.depromeet.memory.api;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
+import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
 import com.depromeet.security.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,7 +30,7 @@ public interface MemoryApi {
     ApiResponse<MemoryResponse> update(
             @LoginMember Long memberId,
             @PathVariable("memoryId") Long memoryId,
-            @RequestBody MemoryUpdateRequest memoryUpdateRequest);
+            @Valid @RequestBody MemoryUpdateRequest memoryUpdateRequest);
 
     @Operation(summary = "타임라인 최신순 조회")
     ApiResponse<?> timeline(
@@ -35,4 +38,10 @@ public interface MemoryApi {
             @RequestParam(value = "cursorId", required = false) Long cursorId,
             @RequestParam(value = "recordAt", required = false) String recordAt,
             @RequestParam(value = "size") Integer size);
+
+    @Operation(summary = "캘린더 조회")
+    ApiResponse<CalendarResponse> getCalendar(
+            @LoginMember Long memberId,
+            @RequestParam("year") Integer year,
+            @Valid @Min(1) @Max(12) @RequestParam("month") Short month);
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -9,8 +9,7 @@ import com.depromeet.security.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import java.time.YearMonth;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,7 +40,5 @@ public interface MemoryApi {
 
     @Operation(summary = "캘린더 조회")
     ApiResponse<CalendarResponse> getCalendar(
-            @LoginMember Long memberId,
-            @RequestParam("year") Integer year,
-            @Valid @Min(1) @Max(12) @RequestParam("month") Short month);
+            @LoginMember Long memberId, @RequestParam("yearMonth") YearMonth yearMonth);
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -20,10 +20,12 @@ public interface MemoryApi {
             @Valid @RequestBody MemoryCreateRequest memoryCreateRequest);
 
     @Operation(summary = "수영 기록 단일 조회")
-    ApiResponse<MemoryResponse> read(@PathVariable("memoryId") Long memoryId);
+    ApiResponse<MemoryResponse> read(
+            @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "수영 기록 수정")
     ApiResponse<MemoryResponse> update(
+            @LoginMember Long memberId,
             @PathVariable("memoryId") Long memoryId,
             @RequestBody MemoryUpdateRequest memoryUpdateRequest);
 

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -10,8 +10,7 @@ import com.depromeet.memory.facade.MemoryFacade;
 import com.depromeet.security.LoginMember;
 import com.depromeet.type.memory.MemorySuccessType;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -58,10 +57,8 @@ public class MemoryController implements MemoryApi {
 
     @GetMapping("/calendar")
     public ApiResponse<CalendarResponse> getCalendar(
-            @LoginMember Long memberId,
-            @RequestParam("year") Integer year,
-            @Valid @Min(1) @Max(12) @RequestParam("month") Short month) {
-        CalendarResponse response = memoryFacade.getCalendar(memberId, year, month);
+            @LoginMember Long memberId, @RequestParam("yearMonth") YearMonth yearMonth) {
+        CalendarResponse response = memoryFacade.getCalendar(memberId, yearMonth);
         return ApiResponse.success(MemorySuccessType.GET_CALENDAR_SUCCESS, response);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -4,11 +4,14 @@ import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
+import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
 import com.depromeet.memory.facade.MemoryFacade;
 import com.depromeet.security.LoginMember;
 import com.depromeet.type.memory.MemorySuccessType;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,8 +56,12 @@ public class MemoryController implements MemoryApi {
         return ApiResponse.success(MemorySuccessType.GET_TIMELINE_SUCCESS, response);
     }
 
-    // public ApiResponse<?> getCalendar(
-    //     @LoginMember Long memberId,
-    //
-    // )
+    @GetMapping("/calendar")
+    public ApiResponse<CalendarResponse> getCalendar(
+            @LoginMember Long memberId,
+            @RequestParam("year") Integer year,
+            @Valid @Min(1) @Max(12) @RequestParam("month") Short month) {
+        CalendarResponse response = memoryFacade.getCalendar(memberId, year, month);
+        return ApiResponse.success(MemorySuccessType.GET_CALENDAR_SUCCESS, response);
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -52,4 +52,9 @@ public class MemoryController implements MemoryApi {
                 memoryFacade.getTimelineByMemberIdAndCursor(memberId, cursorId, recordAt, size);
         return ApiResponse.success(MemorySuccessType.GET_TIMELINE_SUCCESS, response);
     }
+
+    // public ApiResponse<?> getCalendar(
+    //     @LoginMember Long memberId,
+    //
+    // )
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -27,16 +27,18 @@ public class MemoryController implements MemoryApi {
     }
 
     @GetMapping("/{memoryId}")
-    public ApiResponse<MemoryResponse> read(@PathVariable("memoryId") Long memoryId) {
-        MemoryResponse response = memoryFacade.findById(memoryId);
+    public ApiResponse<MemoryResponse> read(
+            @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId) {
+        MemoryResponse response = memoryFacade.findById(memberId, memoryId);
         return ApiResponse.success(MemorySuccessType.GET_RESULT_SUCCESS, response);
     }
 
     @PatchMapping("/{memoryId}")
     public ApiResponse<MemoryResponse> update(
+            @LoginMember Long memberId,
             @PathVariable("memoryId") Long memoryId,
             @Valid @RequestBody MemoryUpdateRequest memoryUpdateRequest) {
-        MemoryResponse response = memoryFacade.update(memoryId, memoryUpdateRequest);
+        MemoryResponse response = memoryFacade.update(memberId, memoryId, memoryUpdateRequest);
         return ApiResponse.success(MemorySuccessType.PATCH_RESULT_SUCCESS, response);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -1,0 +1,62 @@
+package com.depromeet.memory.dto.response;
+
+import com.depromeet.memory.Memory;
+import com.depromeet.memory.Stroke;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class CalendarResponse {
+    private LocalDate today = LocalDate.now();
+    private Map<Integer, DayResponse> memories = new HashMap<>();
+
+    public void addMemory(Memory memory) {
+        int key = memory.getRecordAt().getDayOfMonth();
+        String type = classifyType(memory.getStrokes());
+        Integer totalDistance = getTotalDistance(memory.getLane(), memory.getStrokes());
+        List<StrokeResponse> strokes =
+                memory.getStrokes().stream()
+                        .map(
+                                it ->
+                                        StrokeResponse.builder()
+                                                .name(it.getName())
+                                                .meter(
+                                                        it.getMeter() == null
+                                                                ? it.getLaps()
+                                                                        * memory.getPool().getLane()
+                                                                : it.getMeter())
+                                                .build())
+                        .toList();
+        boolean isAchieved = totalDistance >= memory.getMember().getGoal();
+
+        memories.put(key, DayResponse.of(memory, type, totalDistance, strokes, isAchieved));
+    }
+
+    private String classifyType(List<Stroke> strokes) {
+        if (strokes == null || strokes.isEmpty()) {
+            return "NORMAL";
+        } else if (strokes.size() == 1) {
+            return "SINGLE";
+        } else {
+            return "MULTI";
+        }
+    }
+
+    private Integer getTotalDistance(Short lane, List<Stroke> strokes) {
+        int result = 0;
+        if (strokes == null || strokes.isEmpty()) {
+            return null;
+        }
+        for (Stroke stroke : strokes) {
+            if (stroke.getMeter() != null) {
+                result += stroke.getMeter();
+            } else {
+                result += stroke.getLaps() * lane;
+            }
+        }
+        return result;
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/DayResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/DayResponse.java
@@ -1,0 +1,26 @@
+package com.depromeet.memory.dto.response;
+
+import com.depromeet.memory.Memory;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DayResponse(
+        String type,
+        Integer totalDistance,
+        List<StrokeResponse> strokes,
+        String imageUrl,
+        boolean isAchieved) {
+    public static DayResponse of(
+            Memory memory,
+            String type,
+            int totalDistance,
+            List<StrokeResponse> strokes,
+            boolean isAchieved) {
+        String imageUrl = null;
+        if (!memory.getImages().isEmpty()) {
+            imageUrl = memory.getImages().getFirst().getImageUrl();
+        }
+        return new DayResponse(type, totalDistance, strokes, imageUrl, isAchieved);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -105,7 +105,7 @@ public class MemoryResponse {
                 .toList();
     }
 
-    public static MemoryResponse of(Memory memory) {
+    public static MemoryResponse from(Memory memory) {
         MemberSimpleResponse memberSimple =
                 new MemberSimpleResponse(
                         memory.getMember().getGoal(), memory.getMember().getName());

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponse.java
@@ -1,0 +1,10 @@
+package com.depromeet.memory.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record StrokeResponse(Long strokeId, String name, Short laps, Integer meter) {
+    @Builder
+    public StrokeResponse {}
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponseDto.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponseDto.java
@@ -1,8 +1,0 @@
-package com.depromeet.memory.dto.response;
-
-import lombok.Builder;
-
-public record StrokeResponseDto(Long strokeId, String name, Short laps, Integer meter) {
-    @Builder
-    public StrokeResponseDto {}
-}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponseDto.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponseDto.java
@@ -17,7 +17,7 @@ public record TimelineResponseDto(
         Short heartRate,
         String pace,
         Integer kcal,
-        List<StrokeResponseDto> strokes,
+        List<StrokeResponse> strokes,
         List<MemoryImagesDto> images) {
     @Builder
     public TimelineResponseDto {}

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -17,6 +17,7 @@ import com.depromeet.memory.service.MemoryService;
 import com.depromeet.memory.service.StrokeService;
 import com.depromeet.memory.service.TimelineService;
 import com.depromeet.pool.service.PoolService;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -62,15 +63,14 @@ public class MemoryFacade {
         return timelineService.getTimelineByMemberIdAndCursor(memberId, cursorId, recordAt, size);
     }
 
-    public CalendarResponse getCalendar(Long memberId, Integer year, Short month) {
+    public CalendarResponse getCalendar(Long memberId, YearMonth yearMonth) {
         List<Memory> calendarMemories =
-                calendarService.getCalendarByYearAndMonth(memberId, year, month);
+                calendarService.getCalendarByYearAndMonth(memberId, yearMonth);
 
         CalendarResponse response = new CalendarResponse();
         for (Memory calendarMemory : calendarMemories) {
             response.addMemory(calendarMemory);
         }
-
         return response;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -45,13 +45,13 @@ public class MemoryFacade {
         Memory memory = memoryService.findById(memoryId);
         validatePermission(memory.getMember().getId(), memberId);
         List<Stroke> strokes = strokeService.updateAll(memory, request.getStrokes());
-        return MemoryResponse.of(memoryService.update(memoryId, request, strokes));
+        return MemoryResponse.from(memoryService.update(memoryId, request, strokes));
     }
 
     public MemoryResponse findById(Long memberId, Long memoryId) {
         Memory memory = memoryService.findById(memoryId);
         validatePermission(memory.getMember().getId(), memberId);
-        return MemoryResponse.of(memory);
+        return MemoryResponse.from(memory);
     }
 
     public CustomSliceResponse<?> getTimelineByMemberIdAndCursor(

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -1,5 +1,7 @@
 package com.depromeet.memory.facade;
 
+import static com.depromeet.memory.service.MemoryValidator.*;
+
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.image.service.ImageUploadService;
 import com.depromeet.member.Member;
@@ -39,14 +41,17 @@ public class MemoryFacade {
     }
 
     @Transactional
-    public MemoryResponse update(Long memoryId, MemoryUpdateRequest request) {
+    public MemoryResponse update(Long memberId, Long memoryId, MemoryUpdateRequest request) {
         Memory memory = memoryService.findById(memoryId);
-        List<Stroke> stokes = strokeService.updateAll(memory, request.getStrokes());
-        return MemoryResponse.of(memoryService.update(memoryId, request, stokes));
+        validatePermission(memory.getMember().getId(), memberId);
+        List<Stroke> strokes = strokeService.updateAll(memory, request.getStrokes());
+        return MemoryResponse.of(memoryService.update(memoryId, request, strokes));
     }
 
-    public MemoryResponse findById(Long memoryId) {
-        return MemoryResponse.of(memoryService.findById(memoryId));
+    public MemoryResponse findById(Long memberId, Long memoryId) {
+        Memory memory = memoryService.findById(memoryId);
+        validatePermission(memory.getMember().getId(), memberId);
+        return MemoryResponse.of(memory);
     }
 
     public CustomSliceResponse<?> getTimelineByMemberIdAndCursor(

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -10,7 +10,9 @@ import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
+import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
+import com.depromeet.memory.service.CalendarService;
 import com.depromeet.memory.service.MemoryService;
 import com.depromeet.memory.service.StrokeService;
 import com.depromeet.memory.service.TimelineService;
@@ -24,12 +26,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemoryFacade {
+    private final PoolService poolService;
     private final MemberService memberService;
     private final MemoryService memoryService;
     private final StrokeService strokeService;
-    private final ImageUploadService imageUploadService;
     private final TimelineService timelineService;
-    private final PoolService poolService;
+    private final CalendarService calendarService;
+    private final ImageUploadService imageUploadService;
 
     @Transactional
     public void create(Long memberId, MemoryCreateRequest request) {
@@ -57,5 +60,17 @@ public class MemoryFacade {
     public CustomSliceResponse<?> getTimelineByMemberIdAndCursor(
             Long memberId, Long cursorId, String recordAt, Integer size) {
         return timelineService.getTimelineByMemberIdAndCursor(memberId, cursorId, recordAt, size);
+    }
+
+    public CalendarResponse getCalendar(Long memberId, Integer year, Short month) {
+        List<Memory> calendarMemories =
+                calendarService.getCalendarByYearAndMonth(memberId, year, month);
+
+        CalendarResponse response = new CalendarResponse();
+        for (Memory calendarMemory : calendarMemories) {
+            response.addMemory(calendarMemory);
+        }
+
+        return response;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/service/CalendarService.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/CalendarService.java
@@ -1,8 +1,9 @@
 package com.depromeet.memory.service;
 
 import com.depromeet.memory.Memory;
+import java.time.YearMonth;
 import java.util.List;
 
 public interface CalendarService {
-    List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month);
+    List<Memory> getCalendarByYearAndMonth(Long memberId, YearMonth yearMonth);
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/service/CalendarService.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/CalendarService.java
@@ -1,0 +1,8 @@
+package com.depromeet.memory.service;
+
+import com.depromeet.memory.Memory;
+import java.util.List;
+
+public interface CalendarService {
+    List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month);
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/service/CalendarServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/CalendarServiceImpl.java
@@ -2,6 +2,7 @@ package com.depromeet.memory.service;
 
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.repository.MemoryRepository;
+import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,8 @@ public class CalendarServiceImpl implements CalendarService {
     private final MemoryRepository memoryRepository;
 
     @Override
-    public List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month) {
-        return memoryRepository.getCalendarByYearAndMonth(memberId, year, month);
+    public List<Memory> getCalendarByYearAndMonth(Long memberId, YearMonth yearMonth) {
+        return memoryRepository.getCalendarByYearAndMonth(
+                memberId, yearMonth.getYear(), (short) yearMonth.getMonthValue());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/service/CalendarServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/CalendarServiceImpl.java
@@ -1,0 +1,20 @@
+package com.depromeet.memory.service;
+
+import com.depromeet.memory.Memory;
+import com.depromeet.memory.repository.MemoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarServiceImpl implements CalendarService {
+    private final MemoryRepository memoryRepository;
+
+    @Override
+    public List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month) {
+        return memoryRepository.getCalendarByYearAndMonth(memberId, year, month);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/service/MemoryServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/MemoryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.depromeet.memory.service;
 
-import com.depromeet.exception.ForbiddenException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.member.Member;
@@ -71,8 +70,6 @@ public class MemoryServiceImpl implements MemoryService {
             Long memoryId, MemoryUpdateRequest memoryUpdateRequest, List<Stroke> strokes) {
         Memory memory = findById(memoryId);
 
-        validateMemoryMemberMismatch(memory);
-
         // MemoryDetail 수정
         MemoryDetail updateMemoryDetail =
                 MemoryDetail.builder()
@@ -118,13 +115,6 @@ public class MemoryServiceImpl implements MemoryService {
         return memoryRepository
                 .update(memoryId, updateMemory)
                 .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND));
-    }
-
-    private void validateMemoryMemberMismatch(Memory memory) {
-        Long loginId = authorizationUtil.getLoginId();
-        if (!memory.getMember().getId().equals(loginId)) {
-            throw new ForbiddenException(MemoryErrorType.UPDATE_FAILED);
-        }
     }
 
     private MemoryDetail getMemoryDetail(MemoryCreateRequest memoryCreateRequest) {

--- a/module-presentation/src/main/java/com/depromeet/memory/service/MemoryValidator.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/MemoryValidator.java
@@ -1,0 +1,12 @@
+package com.depromeet.memory.service;
+
+import com.depromeet.exception.ForbiddenException;
+import com.depromeet.type.memory.MemoryErrorType;
+
+public class MemoryValidator {
+    public static void validatePermission(Long memoryMemberId, Long requestMemberId) {
+        if (!memoryMemberId.equals(requestMemberId)) {
+            throw new ForbiddenException(MemoryErrorType.FORBIDDEN);
+        }
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
@@ -5,7 +5,7 @@ import com.depromeet.image.Image;
 import com.depromeet.image.dto.response.MemoryImagesDto;
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
-import com.depromeet.memory.dto.response.StrokeResponseDto;
+import com.depromeet.memory.dto.response.StrokeResponse;
 import com.depromeet.memory.dto.response.TimelineResponseDto;
 import com.depromeet.memory.repository.MemoryRepository;
 import java.time.LocalDate;
@@ -114,13 +114,13 @@ public class TimelineServiceImpl implements TimelineService {
         return totalMeter;
     }
 
-    private List<StrokeResponseDto> strokeToDto(List<Stroke> strokes) {
+    private List<StrokeResponse> strokeToDto(List<Stroke> strokes) {
         if (strokes == null || strokes.isEmpty()) return null;
 
         return strokes.stream()
                 .map(
                         stroke ->
-                                StrokeResponseDto.builder()
+                                StrokeResponse.builder()
                                         .strokeId(stroke.getId())
                                         .name(stroke.getName())
                                         .laps(getLapsFromStroke(stroke))

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolApi.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolApi.java
@@ -1,12 +1,17 @@
 package com.depromeet.pool.api;
 
 import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.pool.dto.request.FavoritePoolCreateRequest;
 import com.depromeet.pool.dto.response.PoolInitialResponse;
 import com.depromeet.pool.dto.response.PoolSearchResponse;
 import com.depromeet.security.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "수영장(Pool)")
@@ -18,4 +23,8 @@ public interface PoolApi {
 
     @Operation(summary = "즐겨찾기 및 최근 검색 수영장 조회")
     ApiResponse<PoolInitialResponse> getFavoriteAndSearchedPools(@LoginMember Long memberId);
+
+    @Operation(summary = "수영장 즐겨찾기 등록 및 삭제")
+    ResponseEntity<URI> createFavoritePool(
+            @LoginMember Long memberId, @Valid @RequestBody FavoritePoolCreateRequest request);
 }

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -5,11 +5,12 @@ spring:
     import: optional:application-secret.properties
   jpa:
     hibernate:
-      ddl-auto: update # 실제 서버에서 사용시 모든 데이터가 다 날아가므로 주의
+      ddl-auto: none # 실제 서버에서 사용시 모든 데이터가 다 날아가므로 주의
     defer-datasource-initialization: false
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 100
     show-sql: true
   sql:
     init:

--- a/module-presentation/src/main/resources/application-prod.yml
+++ b/module-presentation/src/main/resources/application-prod.yml
@@ -10,6 +10,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 100
     show-sql: true
   sql:
     init:

--- a/module-presentation/src/test/java/com/depromeet/memory/mock/FakeMemoryRepository.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/mock/FakeMemoryRepository.java
@@ -118,4 +118,9 @@ public class FakeMemoryRepository implements MemoryRepository {
             LocalDate recordAt) {
         return null;
     }
+
+    @Override
+    public List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month) {
+        return null;
+    }
 }

--- a/module-presentation/src/test/java/com/depromeet/memory/mock/FakeMemoryRepository.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/mock/FakeMemoryRepository.java
@@ -43,6 +43,11 @@ public class FakeMemoryRepository implements MemoryRepository {
     }
 
     @Override
+    public Optional<Memory> findByRecordAt(LocalDate recordAt) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<Memory> update(Long memoryId, Memory memoryUpdate) {
         Optional<Memory> md = data.stream().filter(item -> item.getId().equals(memoryId)).findAny();
         if (md.isEmpty()) {

--- a/module-presentation/src/test/java/com/depromeet/memory/service/MemoryServiceTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/service/MemoryServiceTest.java
@@ -26,7 +26,6 @@ class MemoryServiceTest {
     private FakeMemoryDetailRepository memoryDetailRepository;
 
     private FakeMemberRepository memberRepository;
-    private FakeAuthorizationUtil authorizationUtil;
 
     private FakePoolRepository poolRepository;
 
@@ -48,7 +47,6 @@ class MemoryServiceTest {
         memoryDetailRepository = new FakeMemoryDetailRepository();
 
         memberRepository = new FakeMemberRepository();
-        authorizationUtil = new FakeAuthorizationUtil(userId);
 
         poolRepository = new FakePoolRepository();
 
@@ -64,12 +62,7 @@ class MemoryServiceTest {
 
         // MemoryService
         memoryService =
-                new MemoryServiceImpl(
-                        memoryRepository,
-                        memoryDetailRepository,
-                        memberRepository,
-                        authorizationUtil,
-                        poolRepository);
+                new MemoryServiceImpl(poolRepository, memoryRepository, memoryDetailRepository);
     }
 
     @Test
@@ -83,7 +76,7 @@ class MemoryServiceTest {
                         .build();
 
         // when
-        Memory memory = memoryService.save(memoryCreateRequest);
+        Memory memory = memoryService.save(member1, memoryCreateRequest);
 
         // then
         Assertions.assertThat(memory.getRecordAt()).isEqualTo(LocalDate.of(2024, 7, 15));
@@ -100,7 +93,7 @@ class MemoryServiceTest {
                         .startTime(LocalTime.of(15, 0))
                         .endTime(LocalTime.of(15, 50))
                         .build();
-        Memory memory = memoryService.save(memoryCreateRequest);
+        Memory memory = memoryService.save(member1, memoryCreateRequest);
         MemoryUpdateRequest memoryUpdateRequest =
                 MemoryUpdateRequest.builder()
                         .startTime(LocalTime.of(15, 30))
@@ -130,7 +123,7 @@ class MemoryServiceTest {
                         .startTime(LocalTime.of(15, 0))
                         .endTime(LocalTime.of(15, 50))
                         .build();
-        Memory memory = memoryService.save(memoryCreateRequest);
+        Memory memory = memoryService.save(member1, memoryCreateRequest);
         MemoryUpdateRequest memoryUpdateRequest =
                 MemoryUpdateRequest.builder()
                         .startTime(LocalTime.of(15, 30))


### PR DESCRIPTION
## 🌱 관련 이슈

- close #39 

## 📌 작업 내용 및 특이사항
- 캘린더 조회 API를 구현하였습니다.
- 조회 시 Memory 엔티티와 연관 있는 그래프 객체인 member(ManyToOne), pool(OneToOne), memory_detail(OneToOne), strokes(OneToMany) 객체를 `fetch join`하여 하나의 쿼리로 조회할 수 있도록 하였습니다.
- OneToMany 그래프 객체는 `최대 1개`까지 fetch join을 할 수 있기 때문에 이미지 객체는 따로 조회토록 하였고 이를 최적화 하기 위해 `hibernate.default_batch_size를 100`으로 설정하여 이미지도 `하나의 쿼리`로 모두 조회될 수 있도록 하였습니다. -> 캘린더 조회는 `총 2번의 쿼리`로 처리됨.
- 또한 궁금해하실까봐 Member 엔티티의 Builder를 생성자를 만들어한게 아니라 클래스 최상단으로 옮긴 이유는 Builder.Default를 이용하여 goal을 1000으로 세팅해주도록 하기 위함이었습니다. 이를 사용하기 위해선 Builder를 최상단으로 옮겨야 합니다!
- 또한 Member 도메인의 validator를 따로 분리하였습니다.

## 📝 참고사항
`[조회 시 데이터가 있을 때]`
<img width="731" alt="image" src="https://github.com/user-attachments/assets/53883268-0bda-447f-863c-e9a4b25150fb">
<img width="676" alt="image" src="https://github.com/user-attachments/assets/8942a89b-f7c0-4af4-b04f-450928784a1e">

`[조회 시 데이터가 없을 때]`
<img width="726" alt="image" src="https://github.com/user-attachments/assets/2a3ab98c-39db-4fe4-89f0-8ac3f935e743">

`[조회 조건의 month가 1~12가 아닐때]`
<img width="728" alt="image" src="https://github.com/user-attachments/assets/c29a48be-6773-431c-b13d-19bf3449548f">

`[메모리 저장 시 같은 날짜에 이미 기록이 있으면]`
<img width="823" alt="image" src="https://github.com/user-attachments/assets/bdb89b1b-cc66-4ed9-8dae-d77b8eb65b9f">

