### PR TITLE
refactor: DTO 이름 통일, api 엔드포인트 /api 제거, dto 응답 형식 수정

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
@@ -3,7 +3,7 @@ package com.depromeet.auth.api;
 import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
-import com.depromeet.auth.dto.response.JwtTokenResponseDto;
+import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.dto.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,12 +14,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @Tag(name = "소셜로그인(auth)")
 public interface AuthApi {
     @Operation(summary = "구글 소셜로그인")
-    ApiResponse<JwtTokenResponseDto> loginByGoogle(
+    ApiResponse<JwtTokenResponse> loginByGoogle(
             @Valid @RequestBody final GoogleLoginRequest request);
 
     @Operation(summary = "카카오 소셜로그인")
-    ApiResponse<JwtTokenResponseDto> loginByKakao(
-            @Valid @RequestBody final KakaoLoginRequest request);
+    ApiResponse<JwtTokenResponse> loginByKakao(@Valid @RequestBody final KakaoLoginRequest request);
 
     @Operation(summary = "Access 토큰 재발급 요청")
     ApiResponse<JwtAccessTokenResponse> reissueAccessToken(

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -3,7 +3,7 @@ package com.depromeet.auth.api;
 import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
-import com.depromeet.auth.dto.response.JwtTokenResponseDto;
+import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.auth.facade.AuthFacade;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.type.auth.AuthSuccessType;
@@ -18,14 +18,14 @@ public class AuthController implements AuthApi {
     public final AuthFacade authFacade;
 
     @PostMapping("/google")
-    public ApiResponse<JwtTokenResponseDto> loginByGoogle(
+    public ApiResponse<JwtTokenResponse> loginByGoogle(
             @Valid @RequestBody final GoogleLoginRequest request) {
         return ApiResponse.success(
                 AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByGoogle(request));
     }
 
     @PostMapping("/kakao")
-    public ApiResponse<JwtTokenResponseDto> loginByKakao(
+    public ApiResponse<JwtTokenResponse> loginByKakao(
             @Valid @RequestBody final KakaoLoginRequest request) {
         return ApiResponse.success(AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request));
     }

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/login")
+@RequestMapping("/login")
 public class AuthController implements AuthApi {
     public final AuthFacade authFacade;
 

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/request/AccessTokenDto.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/request/AccessTokenDto.java
@@ -1,3 +1,0 @@
-package com.depromeet.auth.dto.request;
-
-public record AccessTokenDto(String accessToken) {}

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/request/AccessTokenRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/request/AccessTokenRequest.java
@@ -1,0 +1,3 @@
+package com.depromeet.auth.dto.request;
+
+public record AccessTokenRequest(String accessToken) {}

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
@@ -2,8 +2,8 @@ package com.depromeet.auth.dto.response;
 
 import java.util.Objects;
 
-public record JwtTokenResponseDto(Long userId, String accessToken, String refreshToken) {
-    public JwtTokenResponseDto {
+public record JwtTokenResponse(Long userId, String accessToken, String refreshToken) {
+    public JwtTokenResponse {
         Objects.requireNonNull(userId);
         Objects.requireNonNull(accessToken);
         Objects.requireNonNull(refreshToken);

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/RefreshTokenDto.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/RefreshTokenDto.java
@@ -1,8 +1,0 @@
-package com.depromeet.auth.dto.response;
-
-import lombok.Builder;
-
-public record RefreshTokenDto(String refreshToken) {
-    @Builder
-    public RefreshTokenDto {}
-}

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/RefreshTokenResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/RefreshTokenResponse.java
@@ -1,0 +1,8 @@
+package com.depromeet.auth.dto.response;
+
+import lombok.Builder;
+
+public record RefreshTokenResponse(String refreshToken) {
+    @Builder
+    public RefreshTokenResponse {}
+}

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/RefreshTokenResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/RefreshTokenResponse.java
@@ -1,8 +1,0 @@
-package com.depromeet.auth.dto.response;
-
-import lombok.Builder;
-
-public record RefreshTokenResponse(String refreshToken) {
-    @Builder
-    public RefreshTokenResponse {}
-}

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -4,7 +4,7 @@ import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.AccountProfileResponse;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
-import com.depromeet.auth.dto.response.JwtTokenResponseDto;
+import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.auth.dto.response.KakaoAccountProfileResponse;
 import com.depromeet.auth.service.JwtTokenService;
 import com.depromeet.auth.util.GoogleClient;
@@ -26,7 +26,7 @@ public class AuthFacade {
     private final GoogleClient googleClient;
     private final KakaoClient kakaoClient;
 
-    public JwtTokenResponseDto loginByGoogle(GoogleLoginRequest request) {
+    public JwtTokenResponse loginByGoogle(GoogleLoginRequest request) {
         final AccountProfileResponse profile = googleClient.getGoogleAccountProfile(request.code());
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
@@ -35,7 +35,7 @@ public class AuthFacade {
         return jwtTokenService.generateToken(member.getId(), member.getRole());
     }
 
-    public JwtTokenResponseDto loginByKakao(KakaoLoginRequest request) {
+    public JwtTokenResponse loginByKakao(KakaoLoginRequest request) {
         final KakaoAccountProfileResponse profile =
                 kakaoClient.getKakaoAccountProfile(request.code());
         if (profile == null) {

--- a/module-presentation/src/main/java/com/depromeet/auth/service/JwtTokenService.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/service/JwtTokenService.java
@@ -1,7 +1,7 @@
 package com.depromeet.auth.service;
 
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
-import com.depromeet.auth.dto.response.JwtTokenResponseDto;
+import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.exception.ForbiddenException;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.exception.UnauthorizedException;
@@ -28,13 +28,13 @@ public class JwtTokenService {
     private final JwtUtils jwtUtils;
     private final MemberRepository memberRepository;
 
-    public JwtTokenResponseDto generateToken(Long memberId, MemberRole memberRole) {
+    public JwtTokenResponse generateToken(Long memberId, MemberRole memberRole) {
         AccessTokenDto accessToken = jwtUtils.generateAccessToken(memberId, memberRole);
         RefreshTokenDto refreshToken = jwtUtils.generateRefreshToken(memberId, memberRole);
 
         memberRepository.updateRefresh(memberId, refreshToken.refreshToken());
 
-        return new JwtTokenResponseDto(
+        return new JwtTokenResponse(
                 memberId,
                 SecurityConstant.BEARER_PREFIX.getValue() + accessToken.accessToken(),
                 SecurityConstant.BEARER_PREFIX.getValue() + refreshToken.refreshToken());

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
@@ -1,9 +1,9 @@
 package com.depromeet.image.api;
 
 import com.depromeet.dto.response.ApiResponse;
-import com.depromeet.image.dto.request.ImageIdsDto;
-import com.depromeet.image.dto.request.ImageNameDto;
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.request.ImageIdsRequest;
+import com.depromeet.image.dto.request.ImageNameRequest;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -14,17 +14,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "이미지(images)")
 public interface ImageApi {
     @Operation(summary = "이미지 업로드 PresignedURL 생성")
-    ApiResponse<?> getPresignedUrlForUploadImage(@RequestBody ImageNameDto imageNameDto);
+    ApiResponse<?> getPresignedUrlForUploadImage(@RequestBody ImageNameRequest imageNameRequest);
 
     @Operation(summary = "수영 기록 이미지 수정")
     ApiResponse<?> updateImages(
-            @PathVariable("memoryId") Long memoryId, @RequestBody ImageNameDto imageNames);
+            @PathVariable("memoryId") Long memoryId, @RequestBody ImageNameRequest imageNames);
 
     @Operation(summary = "수영 기록 이미지 수정시 추가된 이미지가 잘 올라갔는지 확정")
-    ApiResponse<?> changeImageStatusForAddedImages(@RequestBody ImageIdsDto imageIdsDto);
+    ApiResponse<?> changeImageStatusForAddedImages(@RequestBody ImageIdsRequest imageIdsRequest);
 
     @Operation(summary = "수영 기록의 이미지 조회")
-    ApiResponse<List<MemoryImagesDto>> findImages(@PathVariable("memoryId") Long memoryId);
+    ApiResponse<List<MemoryImagesResponse>> findImages(@PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "Delete images belongs to memory", description = "수영 기록의 이미지 삭제")
     ResponseEntity<?> deleteImages(@PathVariable("memoryId") Long memoryId);

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
@@ -3,7 +3,7 @@ package com.depromeet.image.api;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.image.dto.request.ImageIdsRequest;
 import com.depromeet.image.dto.request.ImageNameRequest;
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -24,7 +24,7 @@ public interface ImageApi {
     ApiResponse<?> changeImageStatusForAddedImages(@RequestBody ImageIdsRequest imageIdsRequest);
 
     @Operation(summary = "수영 기록의 이미지 조회")
-    ApiResponse<List<MemoryImagesResponse>> findImages(@PathVariable("memoryId") Long memoryId);
+    ApiResponse<List<ImagesResponse>> findImages(@PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "Delete images belongs to memory", description = "수영 기록의 이미지 삭제")
     ResponseEntity<?> deleteImages(@PathVariable("memoryId") Long memoryId);

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageApi.java
@@ -3,7 +3,7 @@ package com.depromeet.image.api;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.image.dto.request.ImageIdsRequest;
 import com.depromeet.image.dto.request.ImageNameRequest;
-import com.depromeet.image.dto.response.ImagesResponse;
+import com.depromeet.image.dto.response.ImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -24,7 +24,7 @@ public interface ImageApi {
     ApiResponse<?> changeImageStatusForAddedImages(@RequestBody ImageIdsRequest imageIdsRequest);
 
     @Operation(summary = "수영 기록의 이미지 조회")
-    ApiResponse<List<ImagesResponse>> findImages(@PathVariable("memoryId") Long memoryId);
+    ApiResponse<List<ImageResponse>> findImages(@PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "Delete images belongs to memory", description = "수영 기록의 이미지 삭제")
     ResponseEntity<?> deleteImages(@PathVariable("memoryId") Long memoryId);

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/image")
+@RequestMapping("/image")
 public class ImageController implements ImageApi {
     private final ImageFacade imageFacade;
 

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -5,8 +5,8 @@ import static com.depromeet.type.image.ImageSuccessType.*;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.image.dto.request.ImageIdsRequest;
 import com.depromeet.image.dto.request.ImageNameRequest;
+import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.image.dto.response.ImageUploadResponse;
-import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.image.facade.ImageFacade;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,8 +46,8 @@ public class ImageController implements ImageApi {
     }
 
     @GetMapping("/memory/{memoryId}")
-    public ApiResponse<List<ImagesResponse>> findImages(@PathVariable("memoryId") Long memoryId) {
-        List<ImagesResponse> memoryImages = imageFacade.findImagesByMemoryId(memoryId);
+    public ApiResponse<List<ImageResponse>> findImages(@PathVariable("memoryId") Long memoryId) {
+        List<ImageResponse> memoryImages = imageFacade.findImagesByMemoryId(memoryId);
 
         return ApiResponse.success(GET_IMAGES_SUCCESS, memoryImages);
     }

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -6,7 +6,7 @@ import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.image.dto.request.ImageIdsRequest;
 import com.depromeet.image.dto.request.ImageNameRequest;
 import com.depromeet.image.dto.response.ImageUploadResponse;
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.image.facade.ImageFacade;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,9 +46,8 @@ public class ImageController implements ImageApi {
     }
 
     @GetMapping("/memory/{memoryId}")
-    public ApiResponse<List<MemoryImagesResponse>> findImages(
-            @PathVariable("memoryId") Long memoryId) {
-        List<MemoryImagesResponse> memoryImages = imageFacade.findImagesByMemoryId(memoryId);
+    public ApiResponse<List<ImagesResponse>> findImages(@PathVariable("memoryId") Long memoryId) {
+        List<ImagesResponse> memoryImages = imageFacade.findImagesByMemoryId(memoryId);
 
         return ApiResponse.success(GET_IMAGES_SUCCESS, memoryImages);
     }

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -3,10 +3,10 @@ package com.depromeet.image.api;
 import static com.depromeet.type.image.ImageSuccessType.*;
 
 import com.depromeet.dto.response.ApiResponse;
-import com.depromeet.image.dto.request.ImageIdsDto;
-import com.depromeet.image.dto.request.ImageNameDto;
-import com.depromeet.image.dto.response.ImageUploadResponseDto;
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.request.ImageIdsRequest;
+import com.depromeet.image.dto.request.ImageNameRequest;
+import com.depromeet.image.dto.response.ImageUploadResponse;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import com.depromeet.image.facade.ImageFacade;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,32 +20,35 @@ public class ImageController implements ImageApi {
     private final ImageFacade imageFacade;
 
     @PostMapping("/presigned-url")
-    public ApiResponse<?> getPresignedUrlForUploadImage(@RequestBody ImageNameDto imageNameDto) {
-        List<ImageUploadResponseDto> imageUploadResponseDtos =
-                imageFacade.getPresignedUrlAndSaveImages(imageNameDto.imageNames());
+    public ApiResponse<?> getPresignedUrlForUploadImage(
+            @RequestBody ImageNameRequest imageNameRequest) {
+        List<ImageUploadResponse> imageUploadResponses =
+                imageFacade.getPresignedUrlAndSaveImages(imageNameRequest.imageNames());
 
-        return ApiResponse.success(GENERATE_PRESIGNED_URL_SUCCESS, imageUploadResponseDtos);
+        return ApiResponse.success(GENERATE_PRESIGNED_URL_SUCCESS, imageUploadResponses);
     }
 
     @PatchMapping("/memory/{memoryId}")
     public ApiResponse<?> updateImages(
-            @PathVariable("memoryId") Long memoryId, @RequestBody ImageNameDto imageNames) {
-        List<ImageUploadResponseDto> images =
+            @PathVariable("memoryId") Long memoryId, @RequestBody ImageNameRequest imageNames) {
+        List<ImageUploadResponse> images =
                 imageFacade.updateImages(memoryId, imageNames.imageNames());
 
         return ApiResponse.success(UPDATE_AND_GET_PRESIGNED_URL_SUCCESS, images);
     }
 
     @PatchMapping("/status")
-    public ApiResponse<?> changeImageStatusForAddedImages(@RequestBody ImageIdsDto imageIdsDto) {
-        imageFacade.changeImageStatus(imageIdsDto.imageIds());
+    public ApiResponse<?> changeImageStatusForAddedImages(
+            @RequestBody ImageIdsRequest imageIdsRequest) {
+        imageFacade.changeImageStatus(imageIdsRequest.imageIds());
 
         return ApiResponse.success(CHANGE_IMAGE_STATUS_SUCCESS);
     }
 
     @GetMapping("/memory/{memoryId}")
-    public ApiResponse<List<MemoryImagesDto>> findImages(@PathVariable("memoryId") Long memoryId) {
-        List<MemoryImagesDto> memoryImages = imageFacade.findImagesByMemoryId(memoryId);
+    public ApiResponse<List<MemoryImagesResponse>> findImages(
+            @PathVariable("memoryId") Long memoryId) {
+        List<MemoryImagesResponse> memoryImages = imageFacade.findImagesByMemoryId(memoryId);
 
         return ApiResponse.success(GET_IMAGES_SUCCESS, memoryImages);
     }

--- a/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageIdsRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageIdsRequest.java
@@ -3,4 +3,4 @@ package com.depromeet.image.dto.request;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record ImageNameDto(@NotNull List<String> imageNames) {}
+public record ImageIdsRequest(@NotNull List<Long> imageIds) {}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageNameRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/request/ImageNameRequest.java
@@ -3,4 +3,4 @@ package com.depromeet.image.dto.request;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record ImageIdsDto(@NotNull List<Long> imageIds) {}
+public record ImageNameRequest(@NotNull List<String> imageNames) {}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.image.dto.response;
+
+import com.depromeet.image.domain.Image;
+import lombok.Builder;
+
+public record ImageResponse(Long imageId, String originImageName, String imageName, String url) {
+    @Builder
+    public ImageResponse {}
+
+    public static ImageResponse of(Image image) {
+        return ImageResponse.builder()
+                .imageId(image.getId())
+                .originImageName(image.getOriginImageName())
+                .imageName(image.getImageName())
+                .url(image.getImageUrl())
+                .build();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageUploadResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageUploadResponse.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ImageUploadResponseDto(Long imageId, String imageName, String presignedUrl) {
+public record ImageUploadResponse(Long imageId, String imageName, String presignedUrl) {
     @Builder
-    public ImageUploadResponseDto {}
+    public ImageUploadResponse {}
 
-    public static ImageUploadResponseDto of(ImagePresignedUrlVo imagePresignedUrlVo) {
-        return ImageUploadResponseDto.builder()
+    public static ImageUploadResponse of(ImagePresignedUrlVo imagePresignedUrlVo) {
+        return ImageUploadResponse.builder()
                 .imageId(imagePresignedUrlVo.imageId())
                 .imageName(imagePresignedUrlVo.imageName())
                 .presignedUrl(imagePresignedUrlVo.presignedUrl())

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/ImagesResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/ImagesResponse.java
@@ -1,8 +1,0 @@
-package com.depromeet.image.dto.response;
-
-import lombok.Builder;
-
-public record ImagesResponse(Long imageId, String originImageName, String imageName, String url) {
-    @Builder
-    public ImagesResponse {}
-}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/ImagesResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/ImagesResponse.java
@@ -1,0 +1,8 @@
+package com.depromeet.image.dto.response;
+
+import lombok.Builder;
+
+public record ImagesResponse(Long imageId, String originImageName, String imageName, String url) {
+    @Builder
+    public ImagesResponse {}
+}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesDto.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesDto.java
@@ -1,8 +1,0 @@
-package com.depromeet.image.dto.response;
-
-import lombok.Builder;
-
-public record MemoryImagesDto(Long imageId, String originImageName, String imageName, String url) {
-    @Builder
-    public MemoryImagesDto {}
-}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesResponse.java
@@ -1,9 +1,0 @@
-package com.depromeet.image.dto.response;
-
-import lombok.Builder;
-
-public record MemoryImagesResponse(
-        Long imageId, String originImageName, String imageName, String url) {
-    @Builder
-    public MemoryImagesResponse {}
-}

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/MemoryImagesResponse.java
@@ -1,0 +1,9 @@
+package com.depromeet.image.dto.response;
+
+import lombok.Builder;
+
+public record MemoryImagesResponse(
+        Long imageId, String originImageName, String imageName, String url) {
+    @Builder
+    public MemoryImagesResponse {}
+}

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -3,7 +3,7 @@ package com.depromeet.image.facade;
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.vo.ImagePresignedUrlVo;
 import com.depromeet.image.dto.response.ImageUploadResponse;
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.image.port.in.ImageDeleteUseCase;
 import com.depromeet.image.port.in.ImageGetUseCase;
 import com.depromeet.image.port.in.ImageUpdateUseCase;
@@ -42,12 +42,12 @@ public class ImageFacade {
         imageUpdateUseCase.changeImageStatus(imageIds);
     }
 
-    public List<MemoryImagesResponse> findImagesByMemoryId(Long memoryId) {
+    public List<ImagesResponse> findImagesByMemoryId(Long memoryId) {
         List<Image> images = imageGetUseCase.findImagesByMemoryId(memoryId);
         return images.stream()
                 .map(
                         image ->
-                                MemoryImagesResponse.builder()
+                                ImagesResponse.builder()
                                         .imageId(image.getId())
                                         .originImageName(image.getOriginImageName())
                                         .imageName(image.getImageName())

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -2,8 +2,8 @@ package com.depromeet.image.facade;
 
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.vo.ImagePresignedUrlVo;
+import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.image.dto.response.ImageUploadResponse;
-import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.image.port.in.ImageDeleteUseCase;
 import com.depromeet.image.port.in.ImageGetUseCase;
 import com.depromeet.image.port.in.ImageUpdateUseCase;
@@ -42,12 +42,12 @@ public class ImageFacade {
         imageUpdateUseCase.changeImageStatus(imageIds);
     }
 
-    public List<ImagesResponse> findImagesByMemoryId(Long memoryId) {
+    public List<ImageResponse> findImagesByMemoryId(Long memoryId) {
         List<Image> images = imageGetUseCase.findImagesByMemoryId(memoryId);
         return images.stream()
                 .map(
                         image ->
-                                ImagesResponse.builder()
+                                ImageResponse.builder()
                                         .imageId(image.getId())
                                         .originImageName(image.getOriginImageName())
                                         .imageName(image.getImageName())

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -2,8 +2,8 @@ package com.depromeet.image.facade;
 
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.vo.ImagePresignedUrlVo;
-import com.depromeet.image.dto.response.ImageUploadResponseDto;
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.response.ImageUploadResponse;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import com.depromeet.image.port.in.ImageDeleteUseCase;
 import com.depromeet.image.port.in.ImageGetUseCase;
 import com.depromeet.image.port.in.ImageUpdateUseCase;
@@ -25,29 +25,29 @@ public class ImageFacade {
     private final ImageUpdateUseCase imageUpdateUseCase;
     private final ImageDeleteUseCase imageDeleteUseCase;
 
-    public List<ImageUploadResponseDto> getPresignedUrlAndSaveImages(List<String> imageNames) {
+    public List<ImageUploadResponse> getPresignedUrlAndSaveImages(List<String> imageNames) {
         List<ImagePresignedUrlVo> imagePresignedUrlVos =
                 imageUploadUseCase.getPresignedUrlAndSaveImages(imageNames);
-        return imagePresignedUrlVos.stream().map(ImageUploadResponseDto::of).toList();
+        return imagePresignedUrlVos.stream().map(ImageUploadResponse::of).toList();
     }
 
-    public List<ImageUploadResponseDto> updateImages(Long memoryId, List<String> imageNames) {
+    public List<ImageUploadResponse> updateImages(Long memoryId, List<String> imageNames) {
         Memory memory = memoryService.findById(memoryId);
         List<ImagePresignedUrlVo> imagePresignedUrlVos =
                 imageUpdateUseCase.updateImages(memory, imageNames);
-        return imagePresignedUrlVos.stream().map(ImageUploadResponseDto::of).toList();
+        return imagePresignedUrlVos.stream().map(ImageUploadResponse::of).toList();
     }
 
     public void changeImageStatus(List<Long> imageIds) {
         imageUpdateUseCase.changeImageStatus(imageIds);
     }
 
-    public List<MemoryImagesDto> findImagesByMemoryId(Long memoryId) {
+    public List<MemoryImagesResponse> findImagesByMemoryId(Long memoryId) {
         List<Image> images = imageGetUseCase.findImagesByMemoryId(memoryId);
         return images.stream()
                 .map(
                         image ->
-                                MemoryImagesDto.builder()
+                                MemoryImagesResponse.builder()
                                         .imageId(image.getId())
                                         .originImageName(image.getOriginImageName())
                                         .imageName(image.getImageName())

--- a/module-presentation/src/main/java/com/depromeet/member/api/GoalController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/GoalController.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/goal")
+@RequestMapping("/goal")
 @RequiredArgsConstructor
 public class GoalController implements GoalApi {
     private final MemberService memberService;

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberApi.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberApi.java
@@ -1,7 +1,7 @@
 package com.depromeet.member.api;
 
 import com.depromeet.dto.response.ApiResponse;
-import com.depromeet.member.dto.response.MemberFindOneResponseDto;
+import com.depromeet.member.dto.response.MemberFindOneResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,5 +9,5 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Tag(name = "사용자(members)")
 public interface MemberApi {
     @Operation(summary = "id로 member 단일 검색")
-    ApiResponse<MemberFindOneResponseDto> getMember(@PathVariable("id") Long id);
+    ApiResponse<MemberFindOneResponse> getMember(@PathVariable("id") Long id);
 }

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/member")
+@RequestMapping("/member")
 public class MemberController implements MemberApi {
     private final MemberService memberService;
 

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -1,7 +1,7 @@
 package com.depromeet.member.api;
 
 import com.depromeet.dto.response.ApiResponse;
-import com.depromeet.member.dto.response.MemberFindOneResponseDto;
+import com.depromeet.member.dto.response.MemberFindOneResponse;
 import com.depromeet.member.service.MemberService;
 import com.depromeet.type.member.MemberSuccessType;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @GetMapping("/{id}")
-    public ApiResponse<MemberFindOneResponseDto> getMember(@PathVariable("id") Long id) {
+    public ApiResponse<MemberFindOneResponse> getMember(@PathVariable("id") Long id) {
         return ApiResponse.success(
                 MemberSuccessType.GET_SUCCESS, memberService.findOneMemberResponseById(id));
     }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberCreateRequest.java
@@ -5,11 +5,11 @@ import java.util.Objects;
 
 // 임시
 @Schema(name = "회원가입 정보 입력")
-public record MemberCreateDto(
+public record MemberCreateRequest(
         @Schema(defaultValue = "user") String name,
         @Schema(defaultValue = "user@gmail.com") String email) {
 
-    public MemberCreateDto {
+    public MemberCreateRequest {
         Objects.requireNonNull(email);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberUpdateDto.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberUpdateDto.java
@@ -1,5 +1,0 @@
-package com.depromeet.member.dto.request;
-
-public record MemberUpdateDto(String name, String password) {
-    public MemberUpdateDto {}
-}

--- a/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.depromeet.member.dto.request;
+
+public record MemberUpdateRequest(String name, String password) {
+    public MemberUpdateRequest {}
+}

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberFindOneResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberFindOneResponse.java
@@ -1,0 +1,8 @@
+package com.depromeet.member.dto.response;
+
+import lombok.Builder;
+
+public record MemberFindOneResponse(Long id, String name, String email) {
+    @Builder
+    public MemberFindOneResponse {}
+}

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberFindOneResponseDto.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberFindOneResponseDto.java
@@ -1,8 +1,0 @@
-package com.depromeet.member.dto.response;
-
-import lombok.Builder;
-
-public record MemberFindOneResponseDto(Long id, String name, String email) {
-    @Builder
-    public MemberFindOneResponseDto {}
-}

--- a/module-presentation/src/main/java/com/depromeet/member/mapper/MemberMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/member/mapper/MemberMapper.java
@@ -2,10 +2,10 @@ package com.depromeet.member.mapper;
 
 import com.depromeet.member.Member;
 import com.depromeet.member.MemberRole;
-import com.depromeet.member.dto.request.MemberCreateDto;
+import com.depromeet.member.dto.request.MemberCreateRequest;
 
 public class MemberMapper {
-    public static Member from(MemberCreateDto dto) {
+    public static Member from(MemberCreateRequest dto) {
         return Member.builder().name(dto.name()).email(dto.email()).role(MemberRole.USER).build();
     }
 

--- a/module-presentation/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-presentation/src/main/java/com/depromeet/member/service/MemberService.java
@@ -2,13 +2,13 @@ package com.depromeet.member.service;
 
 import com.depromeet.auth.dto.response.AccountProfileResponse;
 import com.depromeet.member.Member;
-import com.depromeet.member.dto.request.MemberCreateDto;
-import com.depromeet.member.dto.response.MemberFindOneResponseDto;
+import com.depromeet.member.dto.request.MemberCreateRequest;
+import com.depromeet.member.dto.response.MemberFindOneResponse;
 
 public interface MemberService {
-    Member save(MemberCreateDto memberCreate);
+    Member save(MemberCreateRequest memberCreate);
 
-    MemberFindOneResponseDto findOneMemberResponseById(Long id);
+    MemberFindOneResponse findOneMemberResponseById(Long id);
 
     Member findById(Long id);
 

--- a/module-presentation/src/main/java/com/depromeet/member/service/MemberServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/member/service/MemberServiceImpl.java
@@ -5,8 +5,8 @@ import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.member.Member;
 import com.depromeet.member.MemberRole;
-import com.depromeet.member.dto.request.MemberCreateDto;
-import com.depromeet.member.dto.response.MemberFindOneResponseDto;
+import com.depromeet.member.dto.request.MemberCreateRequest;
+import com.depromeet.member.dto.response.MemberFindOneResponse;
 import com.depromeet.member.mapper.MemberMapper;
 import com.depromeet.member.repository.MemberRepository;
 import com.depromeet.type.member.MemberErrorType;
@@ -24,18 +24,18 @@ public class MemberServiceImpl implements MemberService {
 
     @Deprecated
     @Override
-    public Member save(MemberCreateDto memberCreate) {
+    public Member save(MemberCreateRequest memberCreate) {
         Member member = MemberMapper.from(memberCreate);
         return memberRepository.save(member);
     }
 
     @Override
-    public MemberFindOneResponseDto findOneMemberResponseById(Long id) {
+    public MemberFindOneResponse findOneMemberResponseById(Long id) {
         Member member =
                 memberRepository
                         .findById(id)
                         .orElseThrow(() -> new NotFoundException(MemberErrorType.NOT_FOUND));
-        return MemberFindOneResponseDto.builder()
+        return MemberFindOneResponse.builder()
                 .id(member.getId())
                 .name(member.getName())
                 .email(member.getEmail())

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -3,7 +3,7 @@ package com.depromeet.memory.api;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
-import com.depromeet.memory.dto.request.TimelineRequestDto;
+import com.depromeet.memory.dto.request.TimelineRequest;
 import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
 import com.depromeet.security.LoginMember;
@@ -35,7 +35,7 @@ public interface MemoryApi {
 
     @Operation(summary = "타임라인 최신순 조회")
     ApiResponse<?> timeline(
-            @LoginMember Long memberId, @ModelAttribute TimelineRequestDto timelineRequestDto);
+            @LoginMember Long memberId, @ModelAttribute TimelineRequest timelineRequest);
 
     @Operation(summary = "캘린더 조회")
     ApiResponse<CalendarResponse> getCalendar(

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -4,7 +4,7 @@ import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
-import com.depromeet.memory.dto.request.TimelineRequestDto;
+import com.depromeet.memory.dto.request.TimelineRequest;
 import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
 import com.depromeet.memory.facade.MemoryFacade;
@@ -46,10 +46,9 @@ public class MemoryController implements MemoryApi {
     }
 
     @GetMapping("/timeline")
-    public ApiResponse<?> timeline(
-            @LoginMember Long memberId, TimelineRequestDto timelineRequestDto) {
+    public ApiResponse<?> timeline(@LoginMember Long memberId, TimelineRequest timelineRequest) {
         CustomSliceResponse<?> result =
-                memoryFacade.getTimelineByMemberIdAndCursorAndDate(memberId, timelineRequestDto);
+                memoryFacade.getTimelineByMemberIdAndCursorAndDate(memberId, timelineRequest);
         return ApiResponse.success(MemorySuccessType.GET_TIMELINE_SUCCESS, result);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/memory")
+@RequestMapping("/memory")
 public class MemoryController implements MemoryApi {
     private final MemoryFacade memoryFacade;
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/TimelineRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/TimelineRequest.java
@@ -10,7 +10,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TimelineRequestDto {
+public class TimelineRequest {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "최초 조회 이후 나온 timeline 리스트 중 가장 마지막 요소의 memory recordAt")
     private LocalDate cursorRecordAt;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -30,7 +30,7 @@ public class CalendarResponse {
                                                                 : it.getMeter())
                                                 .build())
                         .toList();
-        boolean isAchieved = totalDistance >= memory.getMember().getGoal();
+        boolean isAchieved = isAchieved(memory, totalDistance);
 
         memories.put(key, DayResponse.of(memory, type, totalDistance, strokes, isAchieved));
     }
@@ -58,5 +58,10 @@ public class CalendarResponse {
             }
         }
         return result;
+    }
+
+    private boolean isAchieved(Memory memory, Integer totalDistance) {
+        if (totalDistance == null) return false;
+        return totalDistance >= memory.getMember().getGoal();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/DayResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/DayResponse.java
@@ -14,7 +14,7 @@ public record DayResponse(
     public static DayResponse of(
             Memory memory,
             String type,
-            int totalDistance,
+            Integer totalDistance,
             List<StrokeResponse> strokes,
             boolean isAchieved) {
         String imageUrl = null;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
@@ -1,0 +1,23 @@
+package com.depromeet.memory.dto.response;
+
+import com.depromeet.memory.MemoryDetail;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalTime;
+import lombok.Builder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemoryDetailResponse(
+        Long memoryDetailId, String item, Short heartRate, LocalTime pace, Integer kcal) {
+    @Builder
+    public MemoryDetailResponse {}
+
+    public static MemoryDetailResponse of(MemoryDetail memoryDetail) {
+        return MemoryDetailResponse.builder()
+                .memoryDetailId(memoryDetail.getId())
+                .item(memoryDetail.getItem())
+                .heartRate(memoryDetail.getHeartRate())
+                .pace(memoryDetail.getPace())
+                .kcal(memoryDetail.getKcal())
+                .build();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -6,6 +6,7 @@ import com.depromeet.memory.Memory;
 import com.depromeet.memory.MemoryDetail;
 import com.depromeet.memory.Stroke;
 import com.depromeet.pool.domain.Pool;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MemoryResponse {
     private Long id;
     private MemberSimpleResponse member;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -1,6 +1,6 @@
 package com.depromeet.memory.dto.response;
 
-import com.depromeet.image.dto.response.ImagesResponse;
+import com.depromeet.image.dto.response.ImageResponse;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import lombok.Builder;
@@ -20,7 +20,7 @@ public record TimelineResponse(
         String pace,
         Integer kcal,
         List<StrokeResponse> strokes,
-        List<ImagesResponse> images) {
+        List<ImageResponse> images) {
     @Builder
     public TimelineResponse {}
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -1,10 +1,10 @@
 package com.depromeet.memory.dto.response;
 
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import java.util.List;
 import lombok.Builder;
 
-public record TimelineResponseDto(
+public record TimelineResponse(
         Long memoryId,
         String recordAt,
         String startTime,
@@ -18,9 +18,9 @@ public record TimelineResponseDto(
         String pace,
         Integer kcal,
         List<StrokeResponse> strokes,
-        List<MemoryImagesDto> images) {
+        List<MemoryImagesResponse> images) {
     @Builder
-    public TimelineResponseDto {}
+    public TimelineResponse {}
 }
 
 /*

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -1,9 +1,11 @@
 package com.depromeet.memory.dto.response;
 
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import lombok.Builder;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TimelineResponse(
         Long memoryId,
         String recordAt,
@@ -18,21 +20,7 @@ public record TimelineResponse(
         String pace,
         Integer kcal,
         List<StrokeResponse> strokes,
-        List<MemoryImagesResponse> images) {
+        List<ImagesResponse> images) {
     @Builder
     public TimelineResponse {}
 }
-
-/*
-* ## 📌 Description
-- 조회에 필요한 컬럼
-  - 달력 미리보기 이미지(이건 프론트에서 가져와야 함) , recordAt(날짜, 요일), startTime, endTime
-  - 총거리(stroke 별 거리 계산 후 추가)
-    - 만약 laps 가 있고 거리 없으면 laps * lane으로 계산
-    - meter 면 그냥 그거 가져오면 됨
-  - 영법 별 거리 (stroke meter or laps * memory lane)
-     - 만약 laps 가 있고 거리 없으면 laps * lane으로 계산
-     - meter 면 그냥 그거 가져오면 됨
-  - image, memoryDetail.kcal, memory.diary
-- 조회 방식 : 무한 스크롤 방식(cursor 기반 스크롤)
-* */

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -10,7 +10,7 @@ import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
-import com.depromeet.memory.dto.request.TimelineRequestDto;
+import com.depromeet.memory.dto.request.TimelineRequest;
 import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
 import com.depromeet.memory.service.CalendarService;
@@ -61,8 +61,8 @@ public class MemoryFacade {
     }
 
     public CustomSliceResponse<?> getTimelineByMemberIdAndCursorAndDate(
-            Long memberId, TimelineRequestDto timelineRequestDto) {
-        return timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, timelineRequestDto);
+            Long memberId, TimelineRequest timelineRequest) {
+        return timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, timelineRequest);
     }
 
     public CalendarResponse getCalendar(Long memberId, YearMonth yearMonth) {

--- a/module-presentation/src/main/java/com/depromeet/memory/service/TimelineService.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/TimelineService.java
@@ -2,12 +2,12 @@ package com.depromeet.memory.service;
 
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.memory.Memory;
-import com.depromeet.memory.dto.request.TimelineRequestDto;
-import com.depromeet.memory.dto.response.TimelineResponseDto;
+import com.depromeet.memory.dto.request.TimelineRequest;
+import com.depromeet.memory.dto.response.TimelineResponse;
 
 public interface TimelineService {
     CustomSliceResponse<?> getTimelineByMemberIdAndCursorAndDate(
-            Long memberId, TimelineRequestDto timelineRequestDto);
+            Long memberId, TimelineRequest timelineRequest);
 
-    TimelineResponseDto mapToTimelineResponseDto(Memory memory);
+    TimelineResponse mapToTimelineResponseDto(Memory memory);
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
@@ -2,7 +2,7 @@ package com.depromeet.memory.service;
 
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.image.domain.Image;
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
 import com.depromeet.memory.dto.request.TimelineRequest;
@@ -153,7 +153,7 @@ public class TimelineServiceImpl implements TimelineService {
     }
 
     private List<StrokeResponse> strokeToDto(List<Stroke> strokes) {
-        if (strokes == null || strokes.isEmpty()) return null;
+        if (strokes == null || strokes.isEmpty()) return new ArrayList<>();
 
         return strokes.stream()
                 .map(
@@ -175,13 +175,13 @@ public class TimelineServiceImpl implements TimelineService {
         return stroke.getMeter() != null ? stroke.getMeter() : null;
     }
 
-    private List<MemoryImagesResponse> imagesToDto(List<Image> images) {
+    private List<ImagesResponse> imagesToDto(List<Image> images) {
         if (images == null || images.isEmpty()) return new ArrayList<>();
 
         return images.stream()
                 .map(
                         image ->
-                                MemoryImagesResponse.builder()
+                                ImagesResponse.builder()
                                         .imageId(image.getId())
                                         .originImageName(image.getOriginImageName())
                                         .imageName(image.getImageName())

--- a/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
@@ -2,7 +2,7 @@ package com.depromeet.memory.service;
 
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.image.domain.Image;
-import com.depromeet.image.dto.response.ImagesResponse;
+import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
 import com.depromeet.memory.dto.request.TimelineRequest;
@@ -175,13 +175,13 @@ public class TimelineServiceImpl implements TimelineService {
         return stroke.getMeter() != null ? stroke.getMeter() : null;
     }
 
-    private List<ImagesResponse> imagesToDto(List<Image> images) {
+    private List<ImageResponse> imagesToDto(List<Image> images) {
         if (images == null || images.isEmpty()) return new ArrayList<>();
 
         return images.stream()
                 .map(
                         image ->
-                                ImagesResponse.builder()
+                                ImageResponse.builder()
                                         .imageId(image.getId())
                                         .originImageName(image.getOriginImageName())
                                         .imageName(image.getImageName())

--- a/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/service/TimelineServiceImpl.java
@@ -2,12 +2,12 @@ package com.depromeet.memory.service;
 
 import com.depromeet.dto.response.CustomSliceResponse;
 import com.depromeet.image.domain.Image;
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
-import com.depromeet.memory.dto.request.TimelineRequestDto;
+import com.depromeet.memory.dto.request.TimelineRequest;
 import com.depromeet.memory.dto.response.StrokeResponse;
-import com.depromeet.memory.dto.response.TimelineResponseDto;
+import com.depromeet.memory.dto.response.TimelineResponse;
 import com.depromeet.memory.repository.MemoryRepository;
 import com.depromeet.memory.vo.Timeline;
 import java.time.LocalDate;
@@ -30,13 +30,13 @@ public class TimelineServiceImpl implements TimelineService {
 
     @Override
     public CustomSliceResponse<?> getTimelineByMemberIdAndCursorAndDate(
-            Long memberId, TimelineRequestDto timeline) {
+            Long memberId, TimelineRequest timeline) {
         Timeline timelines = getTimelines(memberId, timeline);
 
         return mapToCustomSliceResponse(timelines);
     }
 
-    private Timeline getTimelines(Long memberId, TimelineRequestDto timeline) {
+    private Timeline getTimelines(Long memberId, TimelineRequest timeline) {
         LocalDate cursorRecordAt = null;
         if (timeline.getCursorRecordAt() != null) {
             cursorRecordAt = timeline.getCursorRecordAt();
@@ -52,7 +52,7 @@ public class TimelineServiceImpl implements TimelineService {
     }
 
     private CustomSliceResponse<?> mapToCustomSliceResponse(Timeline timelines) {
-        List<TimelineResponseDto> result =
+        List<TimelineResponse> result =
                 timelines.getTimelineContents().stream()
                         .map(this::mapToTimelineResponseDto)
                         .toList();
@@ -80,8 +80,8 @@ public class TimelineServiceImpl implements TimelineService {
     }
 
     @Override
-    public TimelineResponseDto mapToTimelineResponseDto(Memory memory) {
-        return TimelineResponseDto.builder()
+    public TimelineResponse mapToTimelineResponseDto(Memory memory) {
+        return TimelineResponse.builder()
                 .memoryId(memory.getId())
                 .recordAt(memory.getRecordAt().toString())
                 .startTime(localTimeToString(memory.getStartTime()))
@@ -175,13 +175,13 @@ public class TimelineServiceImpl implements TimelineService {
         return stroke.getMeter() != null ? stroke.getMeter() : null;
     }
 
-    private List<MemoryImagesDto> imagesToDto(List<Image> images) {
+    private List<MemoryImagesResponse> imagesToDto(List<Image> images) {
         if (images == null || images.isEmpty()) return new ArrayList<>();
 
         return images.stream()
                 .map(
                         image ->
-                                MemoryImagesDto.builder()
+                                MemoryImagesResponse.builder()
                                         .imageId(image.getId())
                                         .originImageName(image.getOriginImageName())
                                         .imageName(image.getImageName())

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/pool")
+@RequestMapping("/pool")
 public class PoolController implements PoolApi {
     private final PoolFacade poolFacade;
 

--- a/module-presentation/src/main/java/com/depromeet/pool/dto/response/PoolSearchInfoResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/dto/response/PoolSearchInfoResponse.java
@@ -1,7 +1,9 @@
 package com.depromeet.pool.dto.response;
 
 import com.depromeet.pool.domain.Pool;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PoolSearchInfoResponse(Long poolId, String name, String address, boolean isFavorite) {
     public static PoolSearchInfoResponse of(Pool pool, boolean isFavorite) {
         return new PoolSearchInfoResponse(

--- a/module-presentation/src/main/java/com/depromeet/security/SecurityConfig.java
+++ b/module-presentation/src/main/java/com/depromeet/security/SecurityConfig.java
@@ -74,8 +74,7 @@ public class SecurityConfig {
                                 .permitAll() // oauth2
                                 .requestMatchers("/swagger-ui/**", "/v3/**", "/favicon.ico")
                                 .permitAll() // swagger
-                                .requestMatchers(
-                                        "/api/v1/auth/**", "/api/login/kakao", "/api/login/google")
+                                .requestMatchers("/login/kakao", "/login/google")
                                 .permitAll() // 로그인 및 회원가입
                                 .anyRequest()
                                 .authenticated());

--- a/module-presentation/src/main/java/com/depromeet/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/module-presentation/src/main/java/com/depromeet/security/oauth/handler/OAuth2SuccessHandler.java
@@ -2,7 +2,7 @@ package com.depromeet.security.oauth.handler;
 
 import static com.depromeet.type.member.MemberErrorType.NOT_FOUND;
 
-import com.depromeet.auth.dto.response.JwtTokenResponseDto;
+import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.auth.service.JwtTokenService;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.exception.NotFoundException;
@@ -53,7 +53,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                         .orElseThrow(() -> new NotFoundException(NOT_FOUND));
         MemberRole memberRole = MemberRole.findByValue(role);
 
-        JwtTokenResponseDto jwtTokenResponseDto =
+        JwtTokenResponse jwtTokenResponse =
                 jwtTokenService.generateToken(member.getId(), memberRole);
 
         // JSON으로 토큰을 응답하는 방식
@@ -64,6 +64,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                         objectMapper.writeValueAsString(
                                 ApiResponse.success(
                                         AuthSuccessType.LOGIN_SUCCESS,
-                                        jwtTokenResponseDto))); // json 응답
+                                        jwtTokenResponse))); // json 응답
     }
 }

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
@@ -48,7 +48,7 @@ public class ImageControllerTest extends ControllerTestConfig {
 
         // then
         mockMvc.perform(
-                        post("/api/image/presigned-url")
+                        post("/image/presigned-url")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isOk())
@@ -77,7 +77,7 @@ public class ImageControllerTest extends ControllerTestConfig {
 
         // then
         mockMvc.perform(
-                        patch("/api/image/memory/{memoryId}", 1)
+                        patch("/image/memory/{memoryId}", 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isOk())
@@ -103,7 +103,7 @@ public class ImageControllerTest extends ControllerTestConfig {
 
         // then
         mockMvc.perform(
-                        patch("/api/image/status")
+                        patch("/image/status")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isOk())
@@ -124,7 +124,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         when(imageFacade.findImagesByMemoryId(anyLong())).thenReturn(images);
 
         // then
-        mockMvc.perform(get("/api/image/memory/{memoryId}", memoryId))
+        mockMvc.perform(get("/image/memory/{memoryId}", memoryId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("IMAGE_5"))
                 .andExpect(jsonPath("$.message").value("이미지 조회에 성공하였습니다"))
@@ -141,7 +141,7 @@ public class ImageControllerTest extends ControllerTestConfig {
     @Test
     @WithCustomMockMember
     void memoryId로_이미지_삭제() throws Exception {
-        mockMvc.perform(delete("/api/image/memory/{memoryId}", 1))
+        mockMvc.perform(delete("/image/memory/{memoryId}", 1))
                 .andExpect(status().isNoContent())
                 .andReturn();
     }

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
@@ -9,8 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.depromeet.image.api.ImageController;
-import com.depromeet.image.dto.response.ImageUploadResponseDto;
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.response.ImageUploadResponse;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import com.depromeet.image.facade.ImageFacade;
 import com.depromeet.memory.config.ControllerTestConfig;
 import com.depromeet.memory.fixture.dto.ImageUploadResponseDtoFixture;
@@ -41,7 +41,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         List<String> imageNames = List.of("image1.png", "image2.png", "image3.png");
         requestBody.put("imageNames", imageNames);
 
-        List<ImageUploadResponseDto> images = ImageUploadResponseDtoFixture.make(imageNames);
+        List<ImageUploadResponse> images = ImageUploadResponseDtoFixture.make(imageNames);
 
         // when
         when(imageFacade.getPresignedUrlAndSaveImages(anyList())).thenReturn(images);
@@ -70,7 +70,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         List<String> imageNames = List.of("image1.png", "image2.png", "image3.png");
         requestBody.put("imageNames", imageNames);
 
-        List<ImageUploadResponseDto> images = ImageUploadResponseDtoFixture.make(imageNames);
+        List<ImageUploadResponse> images = ImageUploadResponseDtoFixture.make(imageNames);
 
         // when
         when(imageFacade.updateImages(anyLong(), anyList())).thenReturn(images);
@@ -118,7 +118,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         // given
         Long memoryId = 1L;
 
-        List<MemoryImagesDto> images = MemoryImagesDtoFixture.make();
+        List<MemoryImagesResponse> images = MemoryImagesDtoFixture.make();
 
         // when
         when(imageFacade.findImagesByMemoryId(anyLong())).thenReturn(images);

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
@@ -9,8 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.depromeet.image.api.ImageController;
+import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.image.dto.response.ImageUploadResponse;
-import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.image.facade.ImageFacade;
 import com.depromeet.memory.config.ControllerTestConfig;
 import com.depromeet.memory.fixture.dto.ImageUploadResponseDtoFixture;
@@ -118,7 +118,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         // given
         Long memoryId = 1L;
 
-        List<ImagesResponse> images = MemoryImagesDtoFixture.make();
+        List<ImageResponse> images = MemoryImagesDtoFixture.make();
 
         // when
         when(imageFacade.findImagesByMemoryId(anyLong())).thenReturn(images);

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/ImageControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.depromeet.image.api.ImageController;
 import com.depromeet.image.dto.response.ImageUploadResponse;
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
 import com.depromeet.image.facade.ImageFacade;
 import com.depromeet.memory.config.ControllerTestConfig;
 import com.depromeet.memory.fixture.dto.ImageUploadResponseDtoFixture;
@@ -118,7 +118,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         // given
         Long memoryId = 1L;
 
-        List<MemoryImagesResponse> images = MemoryImagesDtoFixture.make();
+        List<ImagesResponse> images = MemoryImagesDtoFixture.make();
 
         // when
         when(imageFacade.findImagesByMemoryId(anyLong())).thenReturn(images);

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/MemoryControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/MemoryControllerTest.java
@@ -53,7 +53,7 @@ public class MemoryControllerTest extends ControllerTestConfig {
         requestBody.put("imageIdList", imageIdList);
 
         mockMvc.perform(
-                        post("/api/memory")
+                        post("/memory")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isOk())
@@ -65,7 +65,7 @@ public class MemoryControllerTest extends ControllerTestConfig {
     @Test
     @WithCustomMockMember
     public void 수영기록을_조회합니다() throws Exception {
-        mockMvc.perform(get("/api/memory/{memoryId}", 1))
+        mockMvc.perform(get("/memory/{memoryId}", 1))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("MEMORY_2"))
                 .andExpect(jsonPath("$.message").value("수영 기록 조회에 성공하였습니다"))
@@ -81,7 +81,7 @@ public class MemoryControllerTest extends ControllerTestConfig {
         requestBody.put("startTime", "11:00:00");
         requestBody.put("endTime", "11:50:00");
         mockMvc.perform(
-                        patch("/api/memory/{memoryId}", 1)
+                        patch("/memory/{memoryId}", 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isOk())
@@ -94,7 +94,7 @@ public class MemoryControllerTest extends ControllerTestConfig {
     @WithCustomMockMember
     public void 수영기록_타임라인을_조회합니다() throws Exception {
         mockMvc.perform(
-                        get("/api/memory/timeline")
+                        get("/memory/timeline")
                                 .param("cursorId", "1L")
                                 .param("date", "2024-07")
                                 .param("size", "5"))
@@ -107,7 +107,7 @@ public class MemoryControllerTest extends ControllerTestConfig {
     @Test
     @WithCustomMockMember
     public void 수영기록_캘린더를_조회합니다() throws Exception {
-        mockMvc.perform(get("/api/memory/calendar").param("yearMonth", "2024-07"))
+        mockMvc.perform(get("/memory/calendar").param("yearMonth", "2024-07"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("MEMORY_5"))
                 .andExpect(jsonPath("$.message").value("캘린더 조회에 성공하였습니다"))

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/PoolControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/PoolControllerTest.java
@@ -28,7 +28,7 @@ public class PoolControllerTest extends ControllerTestConfig {
     @Test
     @WithCustomMockMember
     void 이름쿼리로_수영장을_조회합니다() throws Exception {
-        mockMvc.perform(get("/api/pool/search").param("nameQuery", "검색인자"))
+        mockMvc.perform(get("/pool/search").param("nameQuery", "검색인자"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("POOL_1"))
                 .andExpect(jsonPath("$.message").value("수영장 검색을 성공하였습니다"))
@@ -38,7 +38,7 @@ public class PoolControllerTest extends ControllerTestConfig {
     @Test
     @WithCustomMockMember
     void 즐겨찾기_수영장_및_최근_검색_수영장을_조회합니다() throws Exception {
-        mockMvc.perform(get("/api/pool/search/initial"))
+        mockMvc.perform(get("/pool/search/initial"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("POOL_2"))
                 .andExpect(jsonPath("$.message").value("즐겨찾기 및 최근 검색 수영장 조회를 성공하였습니다"))
@@ -53,7 +53,7 @@ public class PoolControllerTest extends ControllerTestConfig {
         BDDMockito.given(poolFacade.putFavoritePool(any(), any())).willReturn("1");
 
         mockMvc.perform(
-                        put("/api/pool/favorite")
+                        put("/pool/favorite")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isCreated())
@@ -68,7 +68,7 @@ public class PoolControllerTest extends ControllerTestConfig {
         BDDMockito.given(poolFacade.putFavoritePool(any(), any())).willReturn(null);
 
         mockMvc.perform(
-                        put("/api/pool/favorite")
+                        put("/pool/favorite")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isNoContent())

--- a/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/ImageUploadResponseDtoFixture.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/ImageUploadResponseDtoFixture.java
@@ -1,20 +1,20 @@
 package com.depromeet.memory.fixture.dto;
 
-import com.depromeet.image.dto.response.ImageUploadResponseDto;
+import com.depromeet.image.dto.response.ImageUploadResponse;
 import java.util.ArrayList;
 import java.util.List;
 
 public class ImageUploadResponseDtoFixture {
-    public static List<ImageUploadResponseDto> make(List<String> imageNames) {
-        List<ImageUploadResponseDto> images = new ArrayList<>();
+    public static List<ImageUploadResponse> make(List<String> imageNames) {
+        List<ImageUploadResponse> images = new ArrayList<>();
         for (int i = 0; i < imageNames.size(); i++) {
-            ImageUploadResponseDto imageUploadResponseDto =
-                    ImageUploadResponseDto.builder()
+            ImageUploadResponse imageUploadResponse =
+                    ImageUploadResponse.builder()
                             .imageId((long) i + 1)
                             .imageName(imageNames.get(i))
                             .presignedUrl("http://" + imageNames.get(i))
                             .build();
-            images.add(imageUploadResponseDto);
+            images.add(imageUploadResponse);
         }
         return images;
     }

--- a/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/MemoryImagesDtoFixture.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/MemoryImagesDtoFixture.java
@@ -1,21 +1,21 @@
 package com.depromeet.memory.fixture.dto;
 
-import com.depromeet.image.dto.response.ImagesResponse;
+import com.depromeet.image.dto.response.ImageResponse;
 import java.util.ArrayList;
 import java.util.List;
 
 public class MemoryImagesDtoFixture {
-    public static List<ImagesResponse> make() {
-        List<ImagesResponse> imagesRespons = new ArrayList<ImagesResponse>();
+    public static List<ImageResponse> make() {
+        List<ImageResponse> imagesRespons = new ArrayList<ImageResponse>();
         for (int i = 0; i < 3; i++) {
-            ImagesResponse imagesResponse =
-                    ImagesResponse.builder()
+            ImageResponse imageResponse =
+                    ImageResponse.builder()
                             .imageId((long) (i + 1))
                             .originImageName("originImage" + i + ".png")
                             .imageName("image" + i + ".png")
                             .url("http://image" + i + ".png")
                             .build();
-            imagesRespons.add(imagesResponse);
+            imagesRespons.add(imageResponse);
         }
         return imagesRespons;
     }

--- a/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/MemoryImagesDtoFixture.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/MemoryImagesDtoFixture.java
@@ -1,22 +1,22 @@
 package com.depromeet.memory.fixture.dto;
 
-import com.depromeet.image.dto.response.MemoryImagesResponse;
+import com.depromeet.image.dto.response.ImagesResponse;
 import java.util.ArrayList;
 import java.util.List;
 
 public class MemoryImagesDtoFixture {
-    public static List<MemoryImagesResponse> make() {
-        List<MemoryImagesResponse> memoryImagesResponses = new ArrayList<MemoryImagesResponse>();
+    public static List<ImagesResponse> make() {
+        List<ImagesResponse> imagesRespons = new ArrayList<ImagesResponse>();
         for (int i = 0; i < 3; i++) {
-            MemoryImagesResponse memoryImagesResponse =
-                    MemoryImagesResponse.builder()
+            ImagesResponse imagesResponse =
+                    ImagesResponse.builder()
                             .imageId((long) (i + 1))
                             .originImageName("originImage" + i + ".png")
                             .imageName("image" + i + ".png")
                             .url("http://image" + i + ".png")
                             .build();
-            memoryImagesResponses.add(memoryImagesResponse);
+            imagesRespons.add(imagesResponse);
         }
-        return memoryImagesResponses;
+        return imagesRespons;
     }
 }

--- a/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/MemoryImagesDtoFixture.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/fixture/dto/MemoryImagesDtoFixture.java
@@ -1,22 +1,22 @@
 package com.depromeet.memory.fixture.dto;
 
-import com.depromeet.image.dto.response.MemoryImagesDto;
+import com.depromeet.image.dto.response.MemoryImagesResponse;
 import java.util.ArrayList;
 import java.util.List;
 
 public class MemoryImagesDtoFixture {
-    public static List<MemoryImagesDto> make() {
-        List<MemoryImagesDto> memoryImagesDtos = new ArrayList<MemoryImagesDto>();
+    public static List<MemoryImagesResponse> make() {
+        List<MemoryImagesResponse> memoryImagesResponses = new ArrayList<MemoryImagesResponse>();
         for (int i = 0; i < 3; i++) {
-            MemoryImagesDto memoryImagesDto =
-                    MemoryImagesDto.builder()
+            MemoryImagesResponse memoryImagesResponse =
+                    MemoryImagesResponse.builder()
                             .imageId((long) (i + 1))
                             .originImageName("originImage" + i + ".png")
                             .imageName("image" + i + ".png")
                             .url("http://image" + i + ".png")
                             .build();
-            memoryImagesDtos.add(memoryImagesDto);
+            memoryImagesResponses.add(memoryImagesResponse);
         }
-        return memoryImagesDtos;
+        return memoryImagesResponses;
     }
 }

--- a/module-presentation/src/test/java/com/depromeet/memory/service/TimelineServiceTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/service/TimelineServiceTest.java
@@ -8,7 +8,7 @@ import com.depromeet.memory.Memory;
 import com.depromeet.memory.Stroke;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.StrokeCreateRequest;
-import com.depromeet.memory.dto.response.TimelineResponseDto;
+import com.depromeet.memory.dto.response.TimelineResponse;
 import com.depromeet.memory.mock.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -111,7 +111,7 @@ public class TimelineServiceTest {
         memoryRepository.save(memory);
 
         // when
-        TimelineResponseDto result = timelineService.mapToTimelineResponseDto(memory);
+        TimelineResponse result = timelineService.mapToTimelineResponseDto(memory);
 
         // then
         assertThat(result.totalMeter()).isEqualTo(expectedTotalMeter);
@@ -125,7 +125,7 @@ public class TimelineServiceTest {
         memoryRepository.save(memory);
 
         // when
-        TimelineResponseDto result = timelineService.mapToTimelineResponseDto(memory);
+        TimelineResponse result = timelineService.mapToTimelineResponseDto(memory);
 
         // then
         assertThat(result.totalMeter()).isEqualTo(expectedTotalMeter);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #114 

## 📌 작업 내용 및 특이사항
- xxxRequestDto, xxxResponseDto -> xxxRequest, xxxResponse로 이름 변경하였습니다.
- api 엔드포인트에서 /api 를 제거하였습니다. 
- DTO 응답 시 null 인 부분은 안 보여주고 List의 경우 빈 배열로 처리하였습니다. 
- MemoryResponse에서 응답값 중 Domain이 리턴되는 경우 Dto로 변경하였습니다. (도메인 계층의 경우 외부로 노출되지 않아야 한다고 생각하여 DTO 로 변경하였습니다. )

아래는 변경 결과입니다. 

Stroke, MemoryDetail, Image 가 입력되지 않은 경우 memory 등록 요청
![필수_값만_입력_memory](https://github.com/user-attachments/assets/ed2cc753-a0d9-4a53-b067-cd70bb501c8f)

memory 단일 조회 응답
![memory_단일_조회](https://github.com/user-attachments/assets/a84010ce-a62c-4e98-9f83-473379b9650d)

memory 수정 응답
![memory_수정](https://github.com/user-attachments/assets/0b881efe-dd46-4f58-9622-1dc63205879d)

timeline 조회 응답
![timeline_조회](https://github.com/user-attachments/assets/f473719e-858e-4f89-a595-0fe971dcec54)

calendar 조회 응답
![calendar_조회](https://github.com/user-attachments/assets/8eae42b1-1908-4012-8ae0-15423b2eb5ba)

image 조회 응답
![image](https://github.com/user-attachments/assets/19c94e9d-f529-4722-8b2f-4caa2ced33a2)


## 📝 참고사항

P.S 
아 그리고 memory에서 memoryDetail 입력 안하고 등록한 이후 memory 수정시에도 memoryDetail 부분 비워놓고 요청 보내면 memory 등록 때는 memoryDetailId 가 생성되지 않았는데 수정 이후에는 memoryDetail 부분을 비워놓아도 memoryDetailId 생성이 되더라고요. 혹시 의도하신 부분인지 아닌지 궁금합니다. 