### PR TITLE
feat: laps 필드 0.5 단위 입력 가능하도록 데이터 타입 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/domain/Stroke.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Stroke.java
@@ -8,11 +8,11 @@ public class Stroke {
     private Long id;
     private Memory memory;
     private String name;
-    private Short laps;
+    private Float laps;
     private Integer meter;
 
     @Builder
-    public Stroke(Long id, Memory memory, String name, Short laps, Integer meter) {
+    public Stroke(Long id, Memory memory, String name, Float laps, Integer meter) {
         this.id = id;
         this.memory = memory;
         this.name = name;

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/command/CreateStrokeCommand.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/command/CreateStrokeCommand.java
@@ -1,3 +1,3 @@
 package com.depromeet.memory.port.in.command;
 
-public record CreateStrokeCommand(String name, Short laps, Integer meter) {}
+public record CreateStrokeCommand(String name, Float laps, Integer meter) {}

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/command/UpdateStrokeCommand.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/command/UpdateStrokeCommand.java
@@ -1,3 +1,3 @@
 package com.depromeet.memory.port.in.command;
 
-public record UpdateStrokeCommand(Long id, String name, Short laps, Integer meter) {}
+public record UpdateStrokeCommand(Long id, String name, Float laps, Integer meter) {}

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -42,7 +42,7 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
         }
 
         Pool pool = null;
-        if(command.poolId() != null) {
+        if (command.poolId() != null) {
             pool = poolPersistencePort.findById(command.poolId()).orElse(null);
         }
         Memory memory =

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -40,7 +40,11 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
         if (memoryDetail != null) {
             memoryDetail = memoryDetailPersistencePort.save(memoryDetail);
         }
-        Pool pool = poolPersistencePort.findById(command.poolId()).orElse(null);
+
+        Pool pool = null;
+        if(command.poolId() != null) {
+            pool = poolPersistencePort.findById(command.poolId()).orElse(null);
+        }
         Memory memory =
                 Memory.builder()
                         .member(writer)

--- a/module-domain/src/test/java/com/depromeet/service/MemoryServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/MemoryServiceTest.java
@@ -121,9 +121,9 @@ class MemoryServiceTest {
     void 회원은_영법을_수정할_수_있다() {
         // given
         UpdateStrokeCommand firstCommand =
-                new UpdateStrokeCommand((Long) null, "자유형", (short) 4, null);
+                new UpdateStrokeCommand((Long) null, "자유형", 4F, null);
         UpdateStrokeCommand secondCommand =
-                new UpdateStrokeCommand((Long) null, "접영", (short) 2, null);
+                new UpdateStrokeCommand((Long) null, "접영", 2F, null);
 
         List<UpdateStrokeCommand> commands = List.of(firstCommand, secondCommand);
 

--- a/module-domain/src/test/java/com/depromeet/service/StrokeServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/StrokeServiceTest.java
@@ -34,7 +34,7 @@ class StrokeServiceTest {
         // given
         List<CreateStrokeCommand> commands = new ArrayList<>();
         for (int i = 0; i < STROKE_NAME_LIST.size(); i++) {
-            Short laps = 2;
+            Float laps = 2F;
             commands.add(new CreateStrokeCommand(STROKE_NAME_LIST.get(i), laps, 50));
         }
         Memory memory =

--- a/module-domain/src/test/java/com/depromeet/service/TimelineServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/TimelineServiceTest.java
@@ -98,10 +98,10 @@ public class TimelineServiceTest {
 
     List<Stroke> saveLapsStroke() {
         List<CreateStrokeCommand> commands = new ArrayList<>();
-        Short laps = 2;
+        Float laps = 2F;
         for (int i = 0; i < STROKE_NAME_LIST.size(); i++) {
             commands.add(new CreateStrokeCommand(STROKE_NAME_LIST.get(i), laps, null));
-            expectedTotalMeter += laps * lane;
+            expectedTotalMeter += (int) (laps * 2) * lane;
         }
 
         return strokeService.saveAll(memory, commands);

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/StrokeEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/StrokeEntity.java
@@ -24,12 +24,12 @@ public class StrokeEntity {
 
     private String name;
 
-    private Short laps;
+    private Float laps;
 
     private Integer meter;
 
     @Builder
-    public StrokeEntity(Long id, MemoryEntity memory, String name, Short laps, Integer meter) {
+    public StrokeEntity(Long id, MemoryEntity memory, String name, Float laps, Integer meter) {
         this.id = id;
         this.memory = memory;
         this.name = name;

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/fixture/memory/StrokeFixture.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/fixture/memory/StrokeFixture.java
@@ -5,7 +5,7 @@ import com.depromeet.memory.domain.Stroke;
 
 public class StrokeFixture {
     public static Stroke mockLapsStroke(Memory memory) {
-        return Stroke.builder().memory(memory).name("자유형").laps((short) 5).build();
+        return Stroke.builder().memory(memory).name("자유형").laps(5F).build();
     }
 
     public static Stroke mockMeterStroke(Memory memory) {

--- a/module-presentation/src/main/java/com/depromeet/memory/annotation/HalfFloatCheck.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/annotation/HalfFloatCheck.java
@@ -1,0 +1,19 @@
+package com.depromeet.memory.annotation;
+
+import com.depromeet.memory.validator.HalfFloatValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = HalfFloatValidator.class)
+public @interface HalfFloatCheck {
+    String message() default "바퀴 수는 0.5 단위로만 입력 가능합니다";
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
@@ -1,6 +1,7 @@
 package com.depromeet.memory.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -51,6 +52,7 @@ public class MemoryCreateRequest {
     private String diary;
 
     // Stroke
+    @Valid
     @Schema(description = "영법 목록")
     private List<StrokeCreateRequest> strokes;
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeCreateRequest.java
@@ -1,8 +1,9 @@
 package com.depromeet.memory.dto.request;
 
+import com.depromeet.memory.annotation.HalfFloatCheck;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record StrokeCreateRequest(
         @Schema(description = "영법 이름", example = "자유형") String name,
-        @Schema(description = "바퀴 수", example = "3") Short laps,
+        @HalfFloatCheck @Schema(description = "바퀴 수", example = "3.5") Float laps,
         @Schema(description = "미터", example = "150") Integer meter) {}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeUpdateRequest.java
@@ -1,9 +1,10 @@
 package com.depromeet.memory.dto.request;
 
+import com.depromeet.memory.annotation.HalfFloatCheck;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record StrokeUpdateRequest(
         @Schema(description = "영법 Id", example = "1") Long id,
         @Schema(description = "영법 이름", example = "자유형") String name,
-        @Schema(description = "바퀴 수", example = "3") Short laps,
+        @HalfFloatCheck @Schema(description = "바퀴 수", example = "3.5") Float laps,
         @Schema(description = "미터", example = "150") Integer meter) {}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -38,7 +38,7 @@ public class CalendarResponse {
                                         .name(it.getName())
                                         .meter(
                                                 it.getMeter() == null
-                                                        ? it.getLaps()
+                                                        ? (int) (it.getLaps() * 2)
                                                                 * memoryDomain.getPool().getLane()
                                                         : it.getMeter())
                                         .build())

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -30,7 +30,7 @@ public class MemoryResponse {
     private LocalTime endTime;
     private LocalTime duration;
     private Short lane;
-    private Integer totalLap;
+    private Float totalLap;
     private Integer totalMeter;
     private String diary;
 
@@ -51,7 +51,7 @@ public class MemoryResponse {
         List<StrokeResponse> resultStrokes = getResultStrokes(strokes, lane);
 
         // 기록 전체 바퀴 수와 미터 수를 계산
-        Integer totalLap = 0;
+        Float totalLap = 0F;
         Integer totalMeter = 0;
         for (StrokeResponse stroke : resultStrokes) {
             totalLap += stroke.laps();
@@ -99,13 +99,13 @@ public class MemoryResponse {
                                         .strokeId(stroke.getId())
                                         .name(stroke.getName())
                                         .laps(stroke.getLaps())
-                                        .meter(stroke.getLaps() * lane)
+                                        .meter((short) (stroke.getLaps() * 2) * lane)
                                         .build();
                             } else {
                                 return StrokeResponse.builder()
                                         .strokeId(stroke.getId())
                                         .name(stroke.getName())
-                                        .laps((short) (stroke.getMeter() / lane))
+                                        .laps((float) stroke.getMeter() / (lane * 2))
                                         .meter(stroke.getMeter())
                                         .build();
                             }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record StrokeResponse(Long strokeId, String name, Short laps, Integer meter) {
+public record StrokeResponse(Long strokeId, String name, Float laps, Integer meter) {
     @Builder
     public StrokeResponse {}
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -70,7 +70,7 @@ public record TimelineResponse(
                 : null;
     }
 
-    private static Short getLapsFromStroke(Stroke stroke) {
+    private static Float getLapsFromStroke(Stroke stroke) {
         return stroke.getLaps() != null ? stroke.getLaps() : null;
     }
 
@@ -126,7 +126,7 @@ public record TimelineResponse(
                 totalMeter += stroke.getMeter();
             } else {
                 if (lane != null) {
-                    totalMeter += (int) stroke.getLaps() * lane;
+                    totalMeter += (int) (stroke.getLaps() * 2) * lane;
                 }
             }
         }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -53,7 +53,9 @@ public class MemoryFacade {
         imageUploadUseCase.changeImageStatusAndAddMemoryIdToImages(
                 newMemory, request.getImageIdList());
 
-        poolSearchLogUseCase.createSearchLog(writer, request.getPoolId());
+        if (request.getPoolId() != null) {
+            poolSearchLogUseCase.createSearchLog(writer, request.getPoolId());
+        }
     }
 
     @Transactional

--- a/module-presentation/src/main/java/com/depromeet/memory/validator/HalfFloatValidator.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/validator/HalfFloatValidator.java
@@ -1,0 +1,15 @@
+package com.depromeet.memory.validator;
+
+import com.depromeet.memory.annotation.HalfFloatCheck;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class HalfFloatValidator implements ConstraintValidator<HalfFloatCheck, Float> {
+    @Override
+    public boolean isValid(Float value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null) {
+            return false;
+        }
+        return value % 0.5 == 0F;
+    }
+}

--- a/module-presentation/src/test/java/com/depromeet/memory/controller/MemoryControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/memory/controller/MemoryControllerTest.java
@@ -64,6 +64,45 @@ public class MemoryControllerTest extends ControllerTestConfig {
 
     @Test
     @WithCustomMockMember
+    void 소수점_바퀴_수는_5만_가능합니다() throws Exception {
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("poolId", 1);
+        requestBody.put("item", "오리발");
+        requestBody.put("heartRate", 115);
+        requestBody.put("pace", "05:00:00");
+        requestBody.put("kcal", 300);
+        requestBody.put("recordAt", "2024-07-24");
+        requestBody.put("startTime", "11:00:00");
+        requestBody.put("endTime", "11:50:00");
+        requestBody.put("lane", 25);
+        requestBody.put("diary", "일기를 기록한다");
+
+        List<Map<String, Object>> strokes = new ArrayList<>();
+        Map<String, Object> stroke = new HashMap<>();
+        stroke.put("name", "자유형");
+        stroke.put("laps", 3.3); // Validation Error
+        stroke.put("meter", 150);
+        strokes.add(stroke);
+
+        requestBody.put("strokes", strokes);
+
+        List<Long> imageIdList = new ArrayList<>();
+        requestBody.put("imageIdList", imageIdList);
+
+        mockMvc.perform(
+                        post("/memory")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_1"))
+                .andExpect(jsonPath("$.message").value("입력 값 검증에 실패하였습니다"))
+                .andExpect(
+                        jsonPath("$.data.fieldErrors[0].reason").value("바퀴 수는 0.5 단위로만 입력 가능합니다"))
+                .andDo(print());
+    }
+
+    @Test
+    @WithCustomMockMember
     public void 수영기록을_조회합니다() throws Exception {
         mockMvc.perform(get("/memory/{memoryId}", 1))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #116

## 📌 작업 내용 및 특이사항
- 바퀴 수를 0.5 단위로 입력이 가능하도록 수정하였습니다.
- 0.5 단위가 맞는지 (3.3 따위는 불가능) 검증할 수 있는 `CustomValidator`를 만들었습니다.

## 📝 참고사항
- @penrose15 님 작업 부분인 Timeline에서도 수정 사항이 있으니 확인해 주시면 감사하겠습니다.
- @its-sky 님 작업 부분인 Pool에서도 수정 사항이 있으니 확인해 주시면 감사하겠습니다.
- 제가 총 거리 계산을 단순히 `바퀴 수 * 레인 길이`로 작성해 버렸는데, 레인 길이는 반 바퀴이므로 `(int) (바퀴 수 * 2) * 레인 길이`로 계산하도록 수정하였습니다.
- 기록 생성 시 (laps 필드 값 5.5)
<img width="853" alt="Screenshot 2024-07-30 at 20 48 40" src="https://github.com/user-attachments/assets/422010ba-9577-43f9-880e-bdc352514ef9">

- 기록 생성 실패 시 (laps 필드 값 5.3)
<img width="841" alt="Screenshot 2024-07-30 at 20 44 15" src="https://github.com/user-attachments/assets/b3346396-90a8-4da7-8602-6e61a2cd1876">