### PR TITLE
feat: 기록 상세 응답 형태 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/image/service/ImageUploadService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageUploadService.java
@@ -79,7 +79,7 @@ public class ImageUploadService implements ImageUploadUseCase {
 
     @Override
     public void changeImageStatusAndAddMemoryIdToImages(Memory memory, List<Long> imageIds) {
-        if (imageIds.isEmpty()) return;
+        if (imageIds == null || imageIds.isEmpty()) return;
         List<Image> images = imagePersistencePort.findImageByIds(imageIds);
         for (Image image : images) {
             image.addMemoryToImage(memory);

--- a/module-domain/src/test/java/com/depromeet/service/MemoryServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/MemoryServiceTest.java
@@ -120,10 +120,8 @@ class MemoryServiceTest {
     @Test
     void 회원은_영법을_수정할_수_있다() {
         // given
-        UpdateStrokeCommand firstCommand =
-                new UpdateStrokeCommand((Long) null, "자유형", 4F, null);
-        UpdateStrokeCommand secondCommand =
-                new UpdateStrokeCommand((Long) null, "접영", 2F, null);
+        UpdateStrokeCommand firstCommand = new UpdateStrokeCommand((Long) null, "자유형", 4F, null);
+        UpdateStrokeCommand secondCommand = new UpdateStrokeCommand((Long) null, "접영", 2F, null);
 
         List<UpdateStrokeCommand> commands = List.of(firstCommand, secondCommand);
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -78,8 +78,6 @@ public class ImageRepository implements ImagePersistencePort {
         List<ImageEntity> imageEntities =
                 queryFactory
                         .selectFrom(imageEntity)
-                        .join(imageEntity.memory, memoryEntity)
-                        .fetchJoin()
                         .where(imageEntity.id.in(ids))
                         .fetch();
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -76,10 +76,7 @@ public class ImageRepository implements ImagePersistencePort {
     @Override
     public List<Image> findImageByIds(List<Long> ids) {
         List<ImageEntity> imageEntities =
-                queryFactory
-                        .selectFrom(imageEntity)
-                        .where(imageEntity.id.in(ids))
-                        .fetch();
+                queryFactory.selectFrom(imageEntity).where(imageEntity.id.in(ids)).fetch();
 
         return imageEntities.stream().map(ImageEntity::toModel).toList();
     }

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageSimpleResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageSimpleResponse.java
@@ -3,13 +3,12 @@ package com.depromeet.image.dto.response;
 import com.depromeet.image.domain.Image;
 import lombok.Builder;
 
-public record ImageSimpleResponse(Long imageId, String imageName, String url) {
+public record ImageSimpleResponse(String imageName, String url) {
     @Builder
     public ImageSimpleResponse {}
 
     public static ImageSimpleResponse of(Image image) {
         return ImageSimpleResponse.builder()
-                .imageId(image.getId())
                 .imageName(image.getImageName())
                 .url(image.getImageUrl())
                 .build();

--- a/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageSimpleResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/image/dto/response/ImageSimpleResponse.java
@@ -1,0 +1,17 @@
+package com.depromeet.image.dto.response;
+
+import com.depromeet.image.domain.Image;
+import lombok.Builder;
+
+public record ImageSimpleResponse(Long imageId, String imageName, String url) {
+    @Builder
+    public ImageSimpleResponse {}
+
+    public static ImageSimpleResponse of(Image image) {
+        return ImageSimpleResponse.builder()
+                .imageId(image.getId())
+                .imageName(image.getImageName())
+                .url(image.getImageUrl())
+                .build();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
@@ -7,13 +7,12 @@ import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemoryDetailResponse(
-        Long memoryDetailId, String item, Short heartRate, LocalTime pace, Integer kcal) {
+        String item, Short heartRate, LocalTime pace, Integer kcal) {
     @Builder
     public MemoryDetailResponse {}
 
     public static MemoryDetailResponse of(MemoryDetail memoryDetail) {
         return MemoryDetailResponse.builder()
-                .memoryDetailId(memoryDetail.getId())
                 .item(memoryDetail.getItem())
                 .heartRate(memoryDetail.getHeartRate())
                 .pace(memoryDetail.getPace())

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
@@ -6,8 +6,7 @@ import java.time.LocalTime;
 import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record MemoryDetailResponse(
-        String item, Short heartRate, LocalTime pace, Integer kcal) {
+public record MemoryDetailResponse(String item, Short heartRate, LocalTime pace, Integer kcal) {
     @Builder
     public MemoryDetailResponse {}
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -1,7 +1,6 @@
 package com.depromeet.memory.dto.response;
 
 import com.depromeet.image.domain.Image;
-import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.image.dto.response.ImageSimpleResponse;
 import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.Memory;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -2,6 +2,7 @@ package com.depromeet.memory.dto.response;
 
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.dto.response.ImageResponse;
+import com.depromeet.image.dto.response.ImageSimpleResponse;
 import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
@@ -24,7 +25,7 @@ public class MemoryResponse {
     private Pool pool;
     private MemoryDetailResponse memoryDetail;
     private List<StrokeResponse> strokes;
-    private List<ImageResponse> images;
+    private List<ImageSimpleResponse> images;
     private LocalDate recordAt;
     private LocalTime startTime;
     private LocalTime endTime;
@@ -86,8 +87,8 @@ public class MemoryResponse {
                 0);
     }
 
-    private static List<ImageResponse> getImageSource(List<Image> images) {
-        return images.stream().map(ImageResponse::of).toList();
+    private static List<ImageSimpleResponse> getImageSource(List<Image> images) {
+        return images.stream().map(ImageSimpleResponse::of).toList();
     }
 
     private static List<StrokeResponse> getResultStrokes(List<Stroke> strokes, Short lane) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #125

## 📌 작업 내용 및 특이사항
- 다음 두 경우 응답에서 불필요한 필드 값을 제거합니다.
- 수영 기록 단일 조회
- 수영 기록 수정
- `memoryDetailId` 필드를 제거하였습니다.
- Image 정보에는 `imageName`, `url` 세 가지 정보만 담아서 제공합니다.
- `imageName`은 이미지 수정 시에 필요합니다.
- 수영 기록 생성 시 이미지 FK 연결 로직에서 발생한 JPQL오류를 수정하였습니다.

## 📝 참고사항
- 수영 기록 단일 조회 성공 시
<img width="852" alt="Screenshot 2024-07-31 at 17 08 29" src="https://github.com/user-attachments/assets/94493dc9-6b6a-4a9c-92c5-23602c313ab9">
<img width="846" alt="Screenshot 2024-07-31 at 17 08 36" src="https://github.com/user-attachments/assets/abb68066-f722-455f-818d-be847e61d59b">
<img width="841" alt="Screenshot 2024-07-31 at 17 08 44" src="https://github.com/user-attachments/assets/13d5fbd7-92df-4a11-86ec-935dfcf94e23">

- 수영 기록 수정 성공 시
<img width="854" alt="Screenshot 2024-07-31 at 17 09 08" src="https://github.com/user-attachments/assets/cb9c5e43-5b59-491f-be89-260acfc82d4a">
<img width="853" alt="Screenshot 2024-07-31 at 17 09 15" src="https://github.com/user-attachments/assets/38efffa8-e260-4200-add2-e3d62f7026e0">
<img width="844" alt="Screenshot 2024-07-31 at 17 09 23" src="https://github.com/user-attachments/assets/5073c8cb-a050-4824-b991-c7edd3375412">
<img width="849" alt="Screenshot 2024-07-31 at 17 09 31" src="https://github.com/user-attachments/assets/69957daa-e413-4b96-a7e9-7ea158b205ba">