### PR TITLE
fix: Auth Transactional read only 제거

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class AuthFacade {
     private final MemberUseCase memberUseCase;
     private final SocialUseCase socialUseCase;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #128

## 📌 작업 내용 및 특이사항
- 소셜로그인 과정 중, 새로운 사용자인 경우 create(insert) 하는 과정이 있는데 AuthFacade에 Transactional read only가 걸려 있어서 401 에러가 발생한 문제를 해결합니다.

## 📝 참고사항
- 서버 에러 로그
<img width="682" alt="Screenshot 2024-07-31 at 18 56 10" src="https://github.com/user-attachments/assets/514f3737-e6fe-466e-9fc7-437ad0335b48">