### PR TITLE
refactor: 수영장 즐겨찾기 API 스펙 변경 및 Logback 설정

### DIFF
--- a/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
@@ -10,7 +10,8 @@ public enum CommonErrorType implements ErrorType {
     METHOD_NOT_ALLOWED("COMMON_5", "잘못된 HTTP 메소드의 요청입니다"),
     INTERNAL_SERVER("COMMON_6", "알 수 없는 서버 에러가 발생했습니다"),
     VALIDATION_FAILED("COMMON_7", "정상적이지 않은 입력값입니다"),
-    BAD_REQUEST("COMMON_8", "잘못된 요청입니다");
+    BAD_REQUEST("COMMON_8", "잘못된 요청입니다"),
+    MISSING_PARAM("COMMON_9", "요청 파라미터가 누락되었습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/pool/PoolSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/pool/PoolSuccessType.java
@@ -4,7 +4,9 @@ import com.depromeet.type.SuccessType;
 
 public enum PoolSuccessType implements SuccessType {
     SEARCH_SUCCESS("POOL_1", "수영장 검색을 성공하였습니다"),
-    INITIAL_GET_SUCCESS("POOL_2", "즐겨찾기 및 최근 검색 수영장 조회를 성공하였습니다");
+    INITIAL_GET_SUCCESS("POOL_2", "즐겨찾기 및 최근 검색 수영장 조회를 성공하였습니다"),
+    FAVORITE_POOL_CREATE_SUCCESS("POOL_3", "수영장 즐겨찾기 등록에 성공하였습니다"),
+    FAVORITE_POOL_DELETE_SUCCESS("POOL_4", "수영장 즐겨찾기 삭제에 성공하였습니다");
 
     private final String code;
     private final String message;

--- a/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
+++ b/module-presentation/src/main/java/com/depromeet/common/GlobalExceptionAdvice.java
@@ -8,6 +8,8 @@ import jakarta.validation.ConstraintDefinitionException;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.UnexpectedTypeException;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -22,6 +25,16 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionAdvice {
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<?>> handleMissingServletRequestParameterException(
+            final MissingServletRequestParameterException ex) {
+        String param = ex.getParameterName();
+        Map<String, String> body = new HashMap<>();
+        body.put("param", param);
+        return new ResponseEntity<>(
+                ApiResponse.fail(CommonErrorType.MISSING_PARAM, 400, body), HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(
             final MethodArgumentNotValidException ex) {

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolApi.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolApi.java
@@ -9,8 +9,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.net.URI;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -29,6 +27,6 @@ public interface PoolApi {
     ApiResponse<PoolInitialResponse> getFavoriteAndSearchedPools(@LoginMember Long memberId);
 
     @Operation(summary = "수영장 즐겨찾기 등록 및 삭제")
-    ResponseEntity<URI> createFavoritePool(
+    ApiResponse<?> createFavoritePool(
             @LoginMember Long memberId, @Valid @RequestBody FavoritePoolCreateRequest request);
 }

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -8,9 +8,7 @@ import com.depromeet.pool.dto.response.PoolSearchResponse;
 import com.depromeet.pool.facade.PoolFacade;
 import com.depromeet.type.pool.PoolSuccessType;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,13 +41,13 @@ public class PoolController implements PoolApi {
     }
 
     @PutMapping("/favorite")
-    public ResponseEntity<URI> createFavoritePool(
+    public ApiResponse<?> createFavoritePool(
             @LoginMember Long memberId, @Valid @RequestBody FavoritePoolCreateRequest request) {
         String uri = poolFacade.putFavoritePool(memberId, request);
 
         if (uri == null) {
-            return ResponseEntity.noContent().build();
+            return ApiResponse.success(PoolSuccessType.FAVORITE_POOL_DELETE_SUCCESS);
         }
-        return ResponseEntity.created(URI.create(uri)).build();
+        return ApiResponse.success(PoolSuccessType.FAVORITE_POOL_CREATE_SUCCESS);
     }
 }

--- a/module-presentation/src/main/resources/application-db.yml
+++ b/module-presentation/src/main/resources/application-db.yml
@@ -10,4 +10,4 @@ spring:
 
 logging:
   level:
-    org.springframework.orm.jpa: DEBUG
+    org.springframework.orm.jpa: INFO

--- a/module-presentation/src/main/resources/console-appender.xml
+++ b/module-presentation/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/module-presentation/src/main/resources/file-error-appender.xml
+++ b/module-presentation/src/main/resources/file-error-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/pium-prod-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/module-presentation/src/main/resources/file-info-appender.xml
+++ b/module-presentation/src/main/resources/file-info-appender.xml
@@ -1,0 +1,13 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/pium-dev-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/module-presentation/src/main/resources/logback-spring.xml
+++ b/module-presentation/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %clr(%5level) %cyan(%logger) - (%msg%n)"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+
+    <!--local-->
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!--dev-->
+    <springProfile name="dev">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!--prod-->
+    <springProfile name="prod">
+        <include resource="console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/module-presentation/src/test/java/com/depromeet/pool/api/PoolControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/pool/api/PoolControllerTest.java
@@ -1,4 +1,4 @@
-package com.depromeet.memory.api;
+package com.depromeet.pool.api;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.depromeet.config.ControllerTestConfig;
 import com.depromeet.config.mock.WithCustomMockMember;
-import com.depromeet.pool.api.PoolController;
 import com.depromeet.pool.facade.PoolFacade;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
@@ -56,7 +55,9 @@ public class PoolControllerTest extends ControllerTestConfig {
                         put("/pool/favorite")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(status().isCreated())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("POOL_3"))
+                .andExpect(jsonPath("$.message").value("수영장 즐겨찾기 등록에 성공하였습니다"))
                 .andDo(print());
     }
 
@@ -71,7 +72,9 @@ public class PoolControllerTest extends ControllerTestConfig {
                         put("/pool/favorite")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("POOL_4"))
+                .andExpect(jsonPath("$.message").value("수영장 즐겨찾기 삭제에 성공하였습니다"))
                 .andDo(print());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #140 

## 📌 작업 내용 및 특이사항
- 수영장 즐겨찾기 API 생성시 201, 삭제 시 204를 반환하던 걸 200으로 통일 후 response body 추가하였습니다
- Logback 구현체 추가하여 콘솔에 찍히는 내용이 가독성 있도록 하였습니다
- 콘솔에 불필요하게 너무 많은 로깅이 찍혀 application-db.yml의 로깅 레벨을 INFO로 수정하였습니다.

## 📝 참고사항
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/a5ce8c91-b0d2-433e-9241-f130f2fbb8b1">
