### PR TITLE
fix: 소셜로그인이 개발 환경, 배포 환경 모두에서 가능하도록 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
@@ -4,7 +4,7 @@ import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.dto.auth.AccountProfileResponse;
 
 public interface SocialUseCase {
-    AccountProfileResponse getGoogleAccountProfile(String code);
+    AccountProfileResponse getGoogleAccountProfile(String code, String origin);
 
-    KakaoAccountProfile getKakaoAccountProfile(String code);
+    KakaoAccountProfile getKakaoAccountProfile(String code, String origin);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/GooglePort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/GooglePort.java
@@ -3,5 +3,5 @@ package com.depromeet.auth.port.out;
 import com.depromeet.dto.auth.AccountProfileResponse;
 
 public interface GooglePort {
-    AccountProfileResponse getGoogleAccountProfile(String code);
+    AccountProfileResponse getGoogleAccountProfile(String code, String origin);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/KakaoPort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/KakaoPort.java
@@ -3,5 +3,5 @@ package com.depromeet.auth.port.out;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 
 public interface KakaoPort {
-    KakaoAccountProfile getKakaoAccountProfile(final String code);
+    KakaoAccountProfile getKakaoAccountProfile(final String code, String origin);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
+++ b/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
@@ -15,12 +15,12 @@ public class SocialService implements SocialUseCase {
     private final GooglePort googlePort;
 
     @Override
-    public AccountProfileResponse getGoogleAccountProfile(String code) {
-        return googlePort.getGoogleAccountProfile(code);
+    public AccountProfileResponse getGoogleAccountProfile(String code, String origin) {
+        return googlePort.getGoogleAccountProfile(code, origin);
     }
 
     @Override
-    public KakaoAccountProfile getKakaoAccountProfile(String code) {
-        return kakaoPort.getKakaoAccountProfile(code);
+    public KakaoAccountProfile getKakaoAccountProfile(String code, String origin) {
+        return kakaoPort.getKakaoAccountProfile(code, origin);
     }
 }

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
@@ -27,7 +27,7 @@ public class GoogleClient implements GooglePort {
     @Value("${spring.security.oauth2.client.registration.google.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    @Value("${spring.security.oauth2.client.registration.google.client-redirect-uri}")
     private String redirectUri;
 
     @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
@@ -41,12 +41,12 @@ public class GoogleClient implements GooglePort {
 
     private final RestTemplate restTemplate;
 
-    public AccountProfileResponse getGoogleAccountProfile(final String code) {
-        final String accessToken = requestGoogleAccessToken(code);
+    public AccountProfileResponse getGoogleAccountProfile(final String code, String origin) {
+        final String accessToken = requestGoogleAccessToken(code, origin);
         return requestGoogleAccountProfile(accessToken);
     }
 
-    private String requestGoogleAccessToken(final String code) {
+    private String requestGoogleAccessToken(final String code, String origin) {
         final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
@@ -56,7 +56,7 @@ public class GoogleClient implements GooglePort {
                                 decodedCode,
                                 clientId,
                                 clientSecret,
-                                redirectUri,
+                                origin + redirectUri,
                                 authorizationCode),
                         headers);
         final GoogleAccessTokenResponse response =

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/KakaoClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/KakaoClient.java
@@ -27,7 +27,7 @@ public class KakaoClient implements KakaoPort {
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    @Value("${spring.security.oauth2.client.registration.kakao.client-redirect-uri}")
     private String redirectUri;
 
     @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
@@ -42,15 +42,15 @@ public class KakaoClient implements KakaoPort {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public KakaoAccountProfile getKakaoAccountProfile(final String code) {
-        final String accessToken = requestKakaoAccessToken(code);
+    public KakaoAccountProfile getKakaoAccountProfile(final String code, String origin) {
+        final String accessToken = requestKakaoAccessToken(code, origin);
         KakaoAccountProfileResponse response = requestKakaoAccountProfile(accessToken);
 
         return KakaoAccountProfile.of(
                 response.getId(), response.getEmail(), response.getNickname());
     }
 
-    private String requestKakaoAccessToken(final String code) {
+    private String requestKakaoAccessToken(final String code, String origin) {
         final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
@@ -59,7 +59,7 @@ public class KakaoClient implements KakaoPort {
         body.add("code", decodedCode);
         body.add("client_id", clientId);
         body.add("client_secret", clientSecret);
-        body.add("redirect_uri", redirectUri);
+        body.add("redirect_uri", origin + redirectUri);
         body.add("grant_type", grantType);
         final HttpEntity<MultiValueMap<String, String>> httpEntity =
                 new HttpEntity<>(body, headers);

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
@@ -7,6 +7,7 @@ import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.dto.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -15,10 +16,13 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface AuthApi {
     @Operation(summary = "구글 소셜로그인")
     ApiResponse<JwtTokenResponse> loginByGoogle(
-            @Valid @RequestBody final GoogleLoginRequest request);
+            @Valid @RequestBody final GoogleLoginRequest request,
+            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "카카오 소셜로그인")
-    ApiResponse<JwtTokenResponse> loginByKakao(@Valid @RequestBody final KakaoLoginRequest request);
+    ApiResponse<JwtTokenResponse> loginByKakao(
+            @Valid @RequestBody final KakaoLoginRequest request,
+            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "Access 토큰 재발급 요청")
     ApiResponse<JwtAccessTokenResponse> reissueAccessToken(

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -7,9 +7,12 @@ import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.auth.facade.AuthFacade;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.type.auth.AuthSuccessType;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,15 +22,19 @@ public class AuthController implements AuthApi {
 
     @PostMapping("/google")
     public ApiResponse<JwtTokenResponse> loginByGoogle(
-            @Valid @RequestBody final GoogleLoginRequest request) {
+            @Valid @RequestBody final GoogleLoginRequest request,
+            HttpServletRequest httpServletRequest) {
+        String origin = getOrigin(httpServletRequest);
         return ApiResponse.success(
-                AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByGoogle(request));
+                AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByGoogle(request, origin));
     }
 
     @PostMapping("/kakao")
     public ApiResponse<JwtTokenResponse> loginByKakao(
-            @Valid @RequestBody final KakaoLoginRequest request) {
-        return ApiResponse.success(AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request));
+            @Valid @RequestBody final KakaoLoginRequest request,
+            HttpServletRequest httpServletRequest) {
+        String origin = getOrigin(httpServletRequest);
+        return ApiResponse.success(AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request, origin));
     }
 
     @PostMapping("/refresh")
@@ -36,5 +43,10 @@ public class AuthController implements AuthApi {
         return ApiResponse.success(
                 AuthSuccessType.REISSUE_ACCESS_TOKEN_SUCCESS,
                 authFacade.getReissuedAccessToken(refreshToken));
+    }
+
+    private static String getOrigin(HttpServletRequest httpServletRequest) {
+        String[] url = httpServletRequest.getHeader("Referer").split("/");
+        return url[0] + "//" + url[2];
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -12,8 +12,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/login")
@@ -34,7 +32,8 @@ public class AuthController implements AuthApi {
             @Valid @RequestBody final KakaoLoginRequest request,
             HttpServletRequest httpServletRequest) {
         String origin = getOrigin(httpServletRequest);
-        return ApiResponse.success(AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request, origin));
+        return ApiResponse.success(
+                AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request, origin));
     }
 
     @PostMapping("/refresh")

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -40,7 +40,8 @@ public class AuthFacade {
     }
 
     public JwtTokenResponse loginByKakao(KakaoLoginRequest request, String origin) {
-        final KakaoAccountProfile profile = socialUseCase.getKakaoAccountProfile(request.code(), origin);
+        final KakaoAccountProfile profile =
+                socialUseCase.getKakaoAccountProfile(request.code(), origin);
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -27,9 +27,9 @@ public class AuthFacade {
     private final SocialUseCase socialUseCase;
     private final CreateTokenUseCase createTokenUseCase;
 
-    public JwtTokenResponse loginByGoogle(GoogleLoginRequest request) {
+    public JwtTokenResponse loginByGoogle(GoogleLoginRequest request, String origin) {
         final AccountProfileResponse profile =
-                socialUseCase.getGoogleAccountProfile(request.code());
+                socialUseCase.getGoogleAccountProfile(request.code(), origin);
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }
@@ -39,8 +39,8 @@ public class AuthFacade {
         return JwtTokenResponse.of(token);
     }
 
-    public JwtTokenResponse loginByKakao(KakaoLoginRequest request) {
-        final KakaoAccountProfile profile = socialUseCase.getKakaoAccountProfile(request.code());
+    public JwtTokenResponse loginByKakao(KakaoLoginRequest request, String origin) {
+        final KakaoAccountProfile profile = socialUseCase.getKakaoAccountProfile(request.code(), origin);
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,9 +27,13 @@ public class MemoryResponse {
     private MemoryDetailResponse memoryDetail;
     private List<StrokeResponse> strokes;
     private List<ImageSimpleResponse> images;
+    @Schema(description = "작성일자", example = "2024-08-01", maxLength = 10, type = "string")
     private LocalDate recordAt;
+    @Schema(description = "시작시간", example = "11:00", maxLength = 8, type = "string")
     private LocalTime startTime;
+    @Schema(description = "종료시간", example = "11:50", maxLength = 8, type = "string")
     private LocalTime endTime;
+    @Schema(description = "운동시간", example = "00:50", maxLength = 8, type = "string")
     private LocalTime duration;
     private Short lane;
     private Float totalLap;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -8,11 +8,10 @@ import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
 import com.depromeet.pool.domain.Pool;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,14 +26,19 @@ public class MemoryResponse {
     private MemoryDetailResponse memoryDetail;
     private List<StrokeResponse> strokes;
     private List<ImageSimpleResponse> images;
+
     @Schema(description = "작성일자", example = "2024-08-01", maxLength = 10, type = "string")
     private LocalDate recordAt;
+
     @Schema(description = "시작시간", example = "11:00", maxLength = 8, type = "string")
     private LocalTime startTime;
+
     @Schema(description = "종료시간", example = "11:50", maxLength = 8, type = "string")
     private LocalTime endTime;
+
     @Schema(description = "운동시간", example = "00:50", maxLength = 8, type = "string")
     private LocalTime duration;
+
     private Short lane;
     private Float totalLap;
     private Integer totalMeter;

--- a/module-presentation/src/main/resources/application-security.yml
+++ b/module-presentation/src/main/resources/application-security.yml
@@ -11,6 +11,7 @@ spring:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: ${KAKAO_REDIRECT_URL}
+            client-redirect-uri: ${KAKAO_CLIENT_REDIRECT_URL}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: kakao
@@ -22,6 +23,7 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             redirect-uri: ${GOOGLE_REDIRECT_URL}
+            client-redirect-uri: ${GOOGLE_CLIENT_REDIRECT_URL}
             authorization-code: ${GOOGLE_AUTH_CODE}
             scope: profile,email
             access-token-url: https://oauth2.googleapis.com/token


### PR DESCRIPTION
## 🌱 관련 이슈

- close #134

## 📌 작업 내용 및 특이사항
- 현재는 소셜로그인이 개발 환경 (localhost)에서만 가능한 상태입니다.
- 배포 환경에서도 정상 동작할 수 있도록 HttpServletRequest의 Referer Header을 활용하여 동적인 redirect가 가능하도록 설정합니다.

## 📝 참고사항
- 카카오와 구글 환경변수가 추가되었습니다. 해당 내용은 슬랙 캔버스에서 확인할 수 있습니다.
- `KAKAO_REDIRECT_URL`은 서버 자체 내부에서 로그인을 진행할 때 사용하는 url입니다.
- `KAKAO_CLIENT_REDIRECT_URL`은 클라이언트에서 로그인을 진행할 때 사용하는 url입니다.
- 구글도 동일합니다.

- 구글 소셜로그인 성공
<img width="392" alt="Screenshot 2024-08-03 at 00 45 43" src="https://github.com/user-attachments/assets/a9b5ab64-d86d-424d-8535-c0358d8a9f70">

- 카카오 소셜로그인 성공
<img width="401" alt="Screenshot 2024-08-03 at 00 45 05" src="https://github.com/user-attachments/assets/2da7796f-52b4-4c2e-b54d-01f2ad70e9e6">

- 데이터베이스
<img width="620" alt="Screenshot 2024-08-03 at 00 50 33" src="https://github.com/user-attachments/assets/83d95dc6-7f6c-4e96-8960-45a9ea468883">
