### PR TITLE
fix: TimelineResponse 불필요한 필드 제거 및 isAchieved 필드 추가

### DIFF
--- a/module-domain/src/test/java/com/depromeet/service/TimelineServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/TimelineServiceTest.java
@@ -106,32 +106,22 @@ public class TimelineServiceTest {
 
         return strokeService.saveAll(memory, commands);
     }
+
+    //     @Test
+    //     void 사용자의_타임라인_기록_조회() {
+    //         // given
     //
-    // @Test
-    // void TimelineResponseDto로_변환_테스트_Stroke_meter로_저장() {
-    //     // given
-    //     List<Stroke> strokes = saveMeterStroke();
-    //     memory.setStrokes(strokes);
-    //     memoryRepository.save(memory);
+    //         // when
     //
-    //     // when
-    //     TimelineResponse result = timelineService.mapToTimelineResponseDto(memory);
+    //         // then
+    //     }
     //
-    //     // then
-    //     assertThat(result.totalMeter()).isEqualTo(expectedTotalMeter);
-    // }
+    //     @Test
+    //     void 타임라인_최초조회이후_cursorRecordAt로_다음_페이지_조회() {
+    //         // given
     //
-    // @Test
-    // void TimelineResponseDto로_변환_테스트_Stroke_laps로_저장() {
-    //     // given
-    //     List<Stroke> strokes = saveLapsStroke();
-    //     memory.setStrokes(strokes);
-    //     memoryRepository.save(memory);
+    //         // when
     //
-    //     // when
-    //     TimelineResponse result = timelineService.mapToTimelineResponseDto(memory);
-    //
-    //     // then
-    //     assertThat(result.totalMeter()).isEqualTo(expectedTotalMeter);
-    // }
+    //         // then
+    //     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #147 

## 📌 작업 내용 및 특이사항
- 준영님이 타임라인에 불필요한 필드 제거 및 목표 달성 여부 필드를 timeline 응답에 추가해달라 하셔서 추가하였습니다. 
- 목표 달성 여부는 isAchieved로 이름을 지정하였습니다

#### TimelineResponse 

- 목표 달성 성공 시
![타임라인_20240803](https://github.com/user-attachments/assets/c7233af8-aa17-435d-b769-dd5f73b11a6c)

- 목표 달성 실패 시
![타임라인_20240803_목표달성_실패](https://github.com/user-attachments/assets/ddd3302e-ed52-4bc5-834c-82cf2da4c911)



## 📝 참고사항
- 타임라인 관련 테스트 코드 작성은 배포 후 바로 진행할 예정이라 주석 처리 하였습니다. (테스트 코드 까지 작성하면 배포 늦어질 것 같아서...)
- 그리고 지금은 급한 것이 아니지만 타임라인과 캘린더 ResponseDTO에 목표 달성 여부를 구하는 비즈니스 로직을 도메인으로 이동 시키는게 더 맞을것 같은데 어떻게 생각하시는지 의견을 듣고 싶습니다