### PR TITLE
fix: TimelineResponse 필드 추가/변경/제거

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
@@ -71,7 +71,7 @@ public class Memory {
                 .build();
     }
 
-    public Integer calculateTotalMeter() {
+    public Integer calculateTotalDistance() {
         if (this.strokes == null || this.strokes.isEmpty()) return null;
 
         int totalDistance = 0;

--- a/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
@@ -71,6 +71,16 @@ public class Memory {
                 .build();
     }
 
+    public String classifyType() {
+        if (this.strokes == null || this.strokes.isEmpty()) {
+            return "NORMAL";
+        } else if (this.strokes.size() == 1) {
+            return "SINGLE";
+        } else {
+            return "MULTI";
+        }
+    }
+
     public Integer calculateTotalDistance() {
         if (this.strokes == null || this.strokes.isEmpty()) return null;
 
@@ -87,8 +97,8 @@ public class Memory {
         return totalDistance;
     }
 
-    public boolean isAchieved(Integer totalMeter) {
-        if (totalMeter == null) return false;
-        return totalMeter >= this.member.getGoal();
+    public boolean isAchieved(Integer totalDistance) {
+        if (totalDistance == null) return false;
+        return totalDistance >= this.member.getGoal();
     }
 }

--- a/module-infrastructure/security/src/main/java/com/depromeet/SecurityConfig.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/SecurityConfig.java
@@ -96,7 +96,11 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(
-                List.of("http://localhost:3000", "https://api.swimie.life"));
+                List.of(
+                        "http://localhost:3000",
+                        "https://api.swimie.life",
+                        "https://swimie.life",
+                        "https://www.swimie.life"));
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.addExposedHeader("Authorization");

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
@@ -24,8 +24,11 @@ public class MemoryCreateRequest {
     @Schema(description = "심박수", example = "129")
     private Short heartRate;
 
-    @Schema(description = "페이스", example = "05:00:00", maxLength = 8, type = "string")
-    private LocalTime pace;
+    @Schema(description = "페이스 분", example = "5", maxLength = 3, type = "int")
+    private int paceMinutes;
+
+    @Schema(description = "페이스 초", example = "30", maxLength = 2, type = "int")
+    private int paceSeconds;
 
     @Schema(description = "칼로리", example = "300")
     private Integer kcal;
@@ -65,7 +68,8 @@ public class MemoryCreateRequest {
             Long poolId,
             String item,
             Short heartRate,
-            LocalTime pace,
+            int paceMinutes,
+            int paceSeconds,
             Integer kcal,
             LocalDate recordAt,
             LocalTime startTime,
@@ -77,7 +81,8 @@ public class MemoryCreateRequest {
         this.poolId = poolId;
         this.item = item;
         this.heartRate = heartRate;
-        this.pace = pace;
+        this.paceMinutes = paceMinutes;
+        this.paceSeconds = paceSeconds;
         this.kcal = kcal;
         this.recordAt = recordAt;
         this.startTime = startTime;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
@@ -38,14 +38,14 @@ public class MemoryCreateRequest {
     @NotNull(message = "수영을 한 날짜를 입력하세요")
     private LocalDate recordAt;
 
-    @DateTimeFormat(pattern = "HH:mm:ss")
+    @DateTimeFormat(pattern = "HH:mm")
     @NotNull(message = "수영을 시작한 시간을 입력하세요")
-    @Schema(description = "수영 시작 시간", example = "11:00:00", maxLength = 8, type = "string")
+    @Schema(description = "수영 시작 시간", example = "11:00", maxLength = 8, type = "string")
     private LocalTime startTime;
 
-    @DateTimeFormat(pattern = "HH:mm:ss")
+    @DateTimeFormat(pattern = "HH:mm")
     @NotNull(message = "수영을 종료한 시간을 입력하세요")
-    @Schema(description = "수영 종료 시간", example = "11:50:00", maxLength = 8, type = "string")
+    @Schema(description = "수영 종료 시간", example = "11:50", maxLength = 8, type = "string")
     private LocalTime endTime;
 
     @Schema(description = "레인 길이", example = "25")

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
@@ -23,8 +23,11 @@ public class MemoryUpdateRequest {
     @Schema(description = "심박수", example = "129")
     private Short heartRate;
 
-    @Schema(description = "페이스", example = "05:00:00", maxLength = 8, type = "string")
-    private LocalTime pace;
+    @Schema(description = "페이스 분", example = "50", maxLength = 2, type = "int")
+    private int paceMinutes;
+
+    @Schema(description = "페이스", example = "30", maxLength = 2, type = "int")
+    private int paceSeconds;
 
     @Schema(description = "칼로리", example = "300")
     private Integer kcal;
@@ -59,7 +62,8 @@ public class MemoryUpdateRequest {
             Long poolId,
             String item,
             Short heartRate,
-            LocalTime pace,
+            int paceMinutes,
+            int paceSeconds,
             Integer kcal,
             LocalDate recordAt,
             LocalTime startTime,
@@ -70,7 +74,8 @@ public class MemoryUpdateRequest {
         this.poolId = poolId;
         this.item = item;
         this.heartRate = heartRate;
-        this.pace = pace;
+        this.paceMinutes = paceMinutes;
+        this.paceSeconds = paceSeconds;
         this.kcal = kcal;
         this.recordAt = recordAt;
         this.startTime = startTime;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
@@ -26,7 +26,7 @@ public class MemoryUpdateRequest {
     @Schema(description = "페이스 분", example = "5", maxLength = 2, type = "int")
     private int paceMinutes;
 
-    @Schema(description = "페이스", example = "30", maxLength = 2, type = "int")
+    @Schema(description = "페이스 초", example = "30", maxLength = 2, type = "int")
     private int paceSeconds;
 
     @Schema(description = "칼로리", example = "300")
@@ -39,12 +39,12 @@ public class MemoryUpdateRequest {
 
     @DateTimeFormat(pattern = "HH:mm")
     @NotNull(message = "수영을 시작한 시간을 입력하세요")
-    @Schema(description = "수영 시작 시간", example = "11:00", maxLength = 8, type = "string")
+    @Schema(description = "수영 시작 시간", example = "11:00", maxLength = 5, type = "string")
     private LocalTime startTime;
 
     @DateTimeFormat(pattern = "HH:mm")
     @NotNull(message = "수영을 종료한 시간을 입력하세요")
-    @Schema(description = "수영 종료 시간", example = "11:50", maxLength = 8, type = "string")
+    @Schema(description = "수영 종료 시간", example = "11:50", maxLength = 5, type = "string")
     private LocalTime endTime;
 
     @Schema(description = "레인 길이", example = "25")

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
@@ -23,7 +23,7 @@ public class MemoryUpdateRequest {
     @Schema(description = "심박수", example = "129")
     private Short heartRate;
 
-    @Schema(description = "페이스 분", example = "50", maxLength = 2, type = "int")
+    @Schema(description = "페이스 분", example = "5", maxLength = 2, type = "int")
     private int paceMinutes;
 
     @Schema(description = "페이스", example = "30", maxLength = 2, type = "int")
@@ -37,14 +37,14 @@ public class MemoryUpdateRequest {
     @NotNull(message = "수영을 한 날짜를 입력하세요")
     private LocalDate recordAt;
 
-    @DateTimeFormat(pattern = "HH:mm:ss")
+    @DateTimeFormat(pattern = "HH:mm")
     @NotNull(message = "수영을 시작한 시간을 입력하세요")
-    @Schema(description = "수영 시작 시간", example = "11:00:00", maxLength = 8, type = "string")
+    @Schema(description = "수영 시작 시간", example = "11:00", maxLength = 8, type = "string")
     private LocalTime startTime;
 
-    @DateTimeFormat(pattern = "HH:mm:ss")
+    @DateTimeFormat(pattern = "HH:mm")
     @NotNull(message = "수영을 종료한 시간을 입력하세요")
-    @Schema(description = "수영 종료 시간", example = "11:50:00", maxLength = 8, type = "string")
+    @Schema(description = "수영 종료 시간", example = "11:50", maxLength = 8, type = "string")
     private LocalTime endTime;
 
     @Schema(description = "레인 길이", example = "25")

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -1,7 +1,6 @@
 package com.depromeet.memory.dto.response;
 
 import com.depromeet.memory.domain.Memory;
-import com.depromeet.memory.domain.Stroke;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,11 +16,10 @@ public class CalendarResponse {
     public static CalendarResponse of(List<Memory> memoryDomains) {
         List<CalendarDetailResponse> memories = new ArrayList<>();
         for (Memory memoryDomain : memoryDomains) {
-            String type = classifyType(memoryDomain.getStrokes());
-            Integer totalDistance =
-                    getTotalDistance(memoryDomain.getLane(), memoryDomain.getStrokes());
+            String type = memoryDomain.classifyType();
+            Integer totalDistance = memoryDomain.calculateTotalDistance();
             List<StrokeResponse> strokes = getStrokeResponses(memoryDomain);
-            boolean isAchieved = isAchieved(memoryDomain, totalDistance);
+            boolean isAchieved = memoryDomain.isAchieved(totalDistance);
 
             memories.add(
                     CalendarDetailResponse.of(
@@ -43,35 +41,5 @@ public class CalendarResponse {
                                                         : it.getMeter())
                                         .build())
                 .toList();
-    }
-
-    private static String classifyType(List<Stroke> strokes) {
-        if (strokes == null || strokes.isEmpty()) {
-            return "NORMAL";
-        } else if (strokes.size() == 1) {
-            return "SINGLE";
-        } else {
-            return "MULTI";
-        }
-    }
-
-    private static Integer getTotalDistance(Short lane, List<Stroke> strokes) {
-        int result = 0;
-        if (strokes == null || strokes.isEmpty()) {
-            return null;
-        }
-        for (Stroke stroke : strokes) {
-            if (stroke.getMeter() != null) {
-                result += stroke.getMeter();
-            } else {
-                result += stroke.getLaps() * lane;
-            }
-        }
-        return result;
-    }
-
-    private static boolean isAchieved(Memory memory, Integer totalDistance) {
-        if (totalDistance == null) return false;
-        return totalDistance >= memory.getMember().getGoal();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
@@ -1,12 +1,14 @@
 package com.depromeet.memory.dto.response;
 
 import com.depromeet.memory.domain.MemoryDetail;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalTime;
 import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record MemoryDetailResponse(String item, Short heartRate, LocalTime pace, Integer kcal) {
+public record MemoryDetailResponse(
+        String item, Short heartRate, @JsonFormat(pattern = "mm:ss") LocalTime pace, Integer kcal) {
     @Builder
     public MemoryDetailResponse {}
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -7,6 +7,7 @@ import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
 import com.depromeet.pool.domain.Pool;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -32,12 +33,15 @@ public class MemoryResponse {
     private LocalDate recordAt;
 
     @Schema(description = "시작시간", example = "11:00", maxLength = 8, type = "string")
+    @JsonFormat(pattern = "HH:mm")
     private LocalTime startTime;
 
     @Schema(description = "종료시간", example = "11:50", maxLength = 8, type = "string")
+    @JsonFormat(pattern = "HH:mm")
     private LocalTime endTime;
 
     @Schema(description = "운동시간", example = "00:50", maxLength = 8, type = "string")
+    @JsonFormat(pattern = "HH:mm")
     private LocalTime duration;
 
     private Short lane;

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -24,6 +24,7 @@ public class MemoryResponse {
     private MemberSimpleResponse member;
     private Pool pool;
     private MemoryDetailResponse memoryDetail;
+    private String type;
     private List<StrokeResponse> strokes;
     private List<ImageSimpleResponse> images;
 
@@ -50,6 +51,7 @@ public class MemoryResponse {
             MemberSimpleResponse member,
             Pool pool,
             MemoryDetail memoryDetail,
+            String type,
             List<Stroke> strokes,
             List<Image> images,
             LocalDate recordAt,
@@ -72,6 +74,7 @@ public class MemoryResponse {
         this.member = member;
         this.pool = pool;
         this.memoryDetail = getMemoryDetail(memoryDetail);
+        this.type = type;
         this.strokes = resultStrokes;
         this.images = getImageSource(images); // 순환참조 방지를 위해 Memory 필드 제외
         this.recordAt = recordAt;
@@ -132,6 +135,7 @@ public class MemoryResponse {
                 .member(memberSimple)
                 .pool(memory.getPool())
                 .memoryDetail(memory.getMemoryDetail())
+                .type(memory.classifyType())
                 .strokes(memory.getStrokes())
                 .images(memory.getImages())
                 .recordAt(memory.getRecordAt())

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -22,7 +22,7 @@ public record TimelineResponse(
         @Schema(description = "총 수영 거리", example = "175") Integer totalDistance,
         @Schema(description = "달성 여부", example = "false") boolean isAchieved,
         @Schema(description = "소모한 칼로리", example = "100") Integer kcal,
-        @Schema(description = "영법 타입(NORMAL, SINGLE, MULTIPLE)", example = "NORMAL") String type,
+        @Schema(description = "영법 타입(NORMAL, SINGLE, MULTI)", example = "NORMAL") String type,
         @Schema(description = "영법별 거리 리스트") List<StrokeResponse> strokes,
         @Schema(description = "이미지") String imageUrl) {
     @Builder

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -21,8 +21,8 @@ public record TimelineResponse(
         @Schema(description = "수영 기록 일기", example = "오늘 수영을 열심히 했다") String diary,
         @Schema(description = "총 수영 거리", example = "175") Integer totalDistance,
         @Schema(description = "달성 여부", example = "false") boolean isAchieved,
-        @Schema(description = "소모한 칼로리", example = "NORMAL") Integer kcal,
-        @Schema(description = "영법 타입(NORMAL, SINGLE, MULTIPLE)", example = "100") String type,
+        @Schema(description = "소모한 칼로리", example = "100") Integer kcal,
+        @Schema(description = "영법 타입(NORMAL, SINGLE, MULTIPLE)", example = "NORMAL") String type,
         @Schema(description = "영법별 거리 리스트") List<StrokeResponse> strokes,
         @Schema(description = "이미지") String imageUrl) {
     @Builder
@@ -41,20 +41,10 @@ public record TimelineResponse(
                 .totalDistance(totalDistance)
                 .isAchieved(memory.isAchieved(totalDistance))
                 .kcal(getKcalFromMemoryDetail(memory))
-                .type(classifyType(memory.getStrokes()))
+                .type(memory.classifyType())
                 .strokes(strokeToDto(memory.getStrokes()))
                 .imageUrl(imagesToDto(memory.getImages()))
                 .build();
-    }
-
-    private static String classifyType(List<Stroke> strokes) {
-        if (strokes == null || strokes.isEmpty()) {
-            return "NORMAL";
-        } else if (strokes.size() == 1) {
-            return "SINGLE";
-        } else {
-            return "MULTI";
-        }
     }
 
     private static List<StrokeResponse> strokeToDto(List<Stroke> strokes) {

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -1,7 +1,6 @@
 package com.depromeet.memory.dto.response;
 
 import com.depromeet.image.domain.Image;
-import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.Stroke;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -20,17 +19,17 @@ public record TimelineResponse(
         @Schema(description = "수영 시작 시간", example = "12:00") String endTime,
         @Schema(description = "수영장 레인 길이", example = "25") Short lane,
         @Schema(description = "수영 기록 일기", example = "오늘 수영을 열심히 했다") String diary,
-        @Schema(description = "총 수영 거리", example = "175") Integer totalMeter,
+        @Schema(description = "총 수영 거리", example = "175") Integer totalDistance,
         @Schema(description = "달성 여부", example = "false") boolean isAchieved,
-        @Schema(description = "memoryDetail PK", example = "1") Long memoryDetailId,
-        @Schema(description = "소모한 칼로리", example = "100") Integer kcal,
+        @Schema(description = "소모한 칼로리", example = "NORMAL") Integer kcal,
+        @Schema(description = "영법 타입(NORMAL, SINGLE, MULTIPLE)", example = "100") String type,
         @Schema(description = "영법별 거리 리스트") List<StrokeResponse> strokes,
-        @Schema(description = "이미지") List<ImageResponse> images) {
+        @Schema(description = "이미지") String imageUrl) {
     @Builder
     public TimelineResponse {}
 
     public static TimelineResponse mapToTimelineResponseDto(Memory memory) {
-        int totalMeter = memory.calculateTotalMeter();
+        Integer totalDistance = memory.calculateTotalDistance();
 
         return TimelineResponse.builder()
                 .memoryId(memory.getId())
@@ -39,13 +38,23 @@ public record TimelineResponse(
                 .endTime(localTimeToString(memory.getEndTime()))
                 .lane(memory.getLane())
                 .diary(memory.getDiary())
-                .totalMeter(totalMeter)
-                .isAchieved(memory.isAchieved(totalMeter))
-                .memoryDetailId(getMemoryDetailId(memory))
+                .totalDistance(totalDistance)
+                .isAchieved(memory.isAchieved(totalDistance))
                 .kcal(getKcalFromMemoryDetail(memory))
+                .type(classifyType(memory.getStrokes()))
                 .strokes(strokeToDto(memory.getStrokes()))
-                .images(imagesToDto(memory.getImages()))
+                .imageUrl(imagesToDto(memory.getImages()))
                 .build();
+    }
+
+    private static String classifyType(List<Stroke> strokes) {
+        if (strokes == null || strokes.isEmpty()) {
+            return "NORMAL";
+        } else if (strokes.size() == 1) {
+            return "SINGLE";
+        } else {
+            return "MULTI";
+        }
     }
 
     private static List<StrokeResponse> strokeToDto(List<Stroke> strokes) {
@@ -63,12 +72,6 @@ public record TimelineResponse(
                 .toList();
     }
 
-    private static Long getMemoryDetailId(Memory memory) {
-        return memory.getMemoryDetail() != null && memory.getMemoryDetail().getId() != null
-                ? memory.getMemoryDetail().getId()
-                : null;
-    }
-
     private static Float getLapsFromStroke(Stroke stroke) {
         return stroke.getLaps() != null ? stroke.getLaps() : null;
     }
@@ -77,19 +80,11 @@ public record TimelineResponse(
         return stroke.getMeter() != null ? stroke.getMeter() : null;
     }
 
-    private static List<ImageResponse> imagesToDto(List<Image> images) {
-        if (images == null || images.isEmpty()) return new ArrayList<>();
+    private static String imagesToDto(List<Image> images) {
+        if (images == null || images.isEmpty()) return null;
 
-        return images.stream()
-                .map(
-                        image ->
-                                ImageResponse.builder()
-                                        .imageId(image.getId())
-                                        .originImageName(image.getOriginImageName())
-                                        .imageName(image.getImageName())
-                                        .url(image.getImageUrl())
-                                        .build())
-                .toList();
+        Image image = images.getFirst();
+        return image.getImageUrl();
     }
 
     private static Integer getKcalFromMemoryDetail(Memory memory) {

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -11,6 +11,7 @@ import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.CreateStrokeCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateStrokeCommand;
+import java.time.LocalTime;
 import java.util.List;
 
 public class MemoryMapper {
@@ -24,11 +25,13 @@ public class MemoryMapper {
     }
 
     public static CreateMemoryCommand toCommand(MemoryCreateRequest request) {
+        LocalTime pace = LocalTime.of(0, request.getPaceMinutes(), request.getPaceSeconds());
+
         return CreateMemoryCommand.builder()
                 .poolId(request.getPoolId())
                 .item(request.getItem())
                 .heartRate(request.getHeartRate())
-                .pace(request.getPace())
+                .pace(pace)
                 .kcal(request.getKcal())
                 .recordAt(request.getRecordAt())
                 .startTime(request.getStartTime())
@@ -46,11 +49,13 @@ public class MemoryMapper {
     }
 
     public static UpdateMemoryCommand toCommand(MemoryUpdateRequest request) {
+        LocalTime pace = LocalTime.of(0, request.getPaceMinutes(), request.getPaceSeconds());
+
         return UpdateMemoryCommand.builder()
                 .poolId(request.getPoolId())
                 .item(request.getItem())
                 .heartRate(request.getHeartRate())
-                .pace(request.getPace())
+                .pace(pace)
                 .kcal(request.getKcal())
                 .recordAt(request.getRecordAt())
                 .startTime(request.getStartTime())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #158 

## 📌 작업 내용 및 특이사항
- 타임라인 필드 변경
  - 총 거리 필드명 변경 (TotalMeter -> TotalDistance)
  - memoryDetailId 필드 제거
  - 영법 타입 추가 (NORMAL | SINGLE | MULTI)
  - imageResponse에서 imageUrl만 보여줌

## 📝 참고사항

- 타임라인 Response
![image](https://github.com/user-attachments/assets/d9cc9987-803a-49c4-9f65-93726006c993)


- 기본 오수완 시 response
![타임라인_응답_수정(타입추가_NORMAL)](https://github.com/user-attachments/assets/02168b28-8d76-43a2-8fb7-4cdc44bcdad9)

- 영법 1개 response
![타임라인_응답_수정(타입추가_Single)](https://github.com/user-attachments/assets/3f1b766e-7d5b-490a-9573-b2ccb53dfb7a)

- 영법 여러개 response
![타임라인_응답_수정(타입추가_MULTI)](https://github.com/user-attachments/assets/d787ceee-e70c-4521-8335-5bf74ea97573)

- 이미지 url response
![타임라인_응답_수정(타임라인_이미지URL)](https://github.com/user-attachments/assets/74022179-d32f-4728-9c21-ce4851156a90)

- memoryCreateRequest
![image](https://github.com/user-attachments/assets/321c636e-775e-4a04-b0c3-2ff02a4251fa)

- memoryUpdateRequest
![image](https://github.com/user-attachments/assets/25c89651-f498-4800-8dc9-86429f5458db)

- memoryUpdateResponse
![image](https://github.com/user-attachments/assets/7d314128-e7ce-498d-abed-9a1f2b1a677e)

- memoryResponse
![image](https://github.com/user-attachments/assets/9b3a0042-d46c-4c50-9c29-ec9e146ee188)

