### PR TITLE
refactor: 캘린더 조회 및 타임라인 조회 API 스펙 변경

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSimpleResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSimpleResponse.java
@@ -1,3 +1,14 @@
 package com.depromeet.member.dto.response;
 
-public record MemberSimpleResponse(Integer goal, String name) {}
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemberSimpleResponse(Integer goal, String name) {
+    public static MemberSimpleResponse from(Integer goal) {
+        return new MemberSimpleResponse(goal, null);
+    }
+
+    public static MemberSimpleResponse of(Integer goal, String name) {
+        return new MemberSimpleResponse(goal, name);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -1,5 +1,7 @@
 package com.depromeet.memory.dto.response;
 
+import com.depromeet.member.domain.Member;
+import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.Stroke;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -12,9 +14,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CalendarResponse {
+    private MemberSimpleResponse member;
     private List<CalendarDetailResponse> memories;
 
-    public static CalendarResponse of(List<Memory> memoryDomains) {
+    public static CalendarResponse of(Member member, List<Memory> memoryDomains) {
         List<CalendarDetailResponse> memories = new ArrayList<>();
         for (Memory memoryDomain : memoryDomains) {
             String type = classifyType(memoryDomain.getStrokes());
@@ -27,7 +30,8 @@ public class CalendarResponse {
                     CalendarDetailResponse.of(
                             memoryDomain, type, totalDistance, strokes, isAchieved));
         }
-        return new CalendarResponse(memories);
+        return new CalendarResponse(
+                MemberSimpleResponse.of(member.getGoal(), member.getName()), memories);
     }
 
     public static List<StrokeResponse> getStrokeResponses(Memory memoryDomain) {

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
@@ -1,11 +1,13 @@
 package com.depromeet.memory.dto.response;
 
+import com.depromeet.member.dto.response.MemberSimpleResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 
 public record TimelineSliceResponse(
         @Schema(description = "타임라인 리스트") List<TimelineResponse> content,
+        @Schema(description = "멤버 목표", example = "1000") MemberSimpleResponse member,
         @Schema(description = "페이지 크기", example = "10") int pageSize,
         @Schema(description = "커서 기준이 되는 recordAt", example = "2024-07-31") String cursorRecordAt,
         @Schema(description = "다음 페이지가 존재하는지 확인", example = "true") boolean hasNext) {

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -92,14 +92,16 @@ public class MemoryFacade {
         Timeline timeline =
                 timelineUseCase.getTimelineByMemberIdAndCursorAndDate(
                         memberId, cursorRecordAt, date, showNewer);
+        Member member = timeline.getTimelineContents().getFirst().getMember();
 
-        return MemoryMapper.toSliceResponse(timeline);
+        return MemoryMapper.toSliceResponse(member, timeline);
     }
 
     public CalendarResponse getCalendar(Long memberId, Integer year, Short month) {
         YearMonth yearMonth = YearMonth.of(year, month);
         List<Memory> calendarMemories =
                 calendarUseCase.getCalendarByYearAndMonth(memberId, yearMonth);
-        return CalendarResponse.of(calendarMemories);
+        Member member = calendarMemories.getFirst().getMember();
+        return CalendarResponse.of(member, calendarMemories);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -1,5 +1,7 @@
 package com.depromeet.memory.mapper;
 
+import com.depromeet.member.domain.Member;
+import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.vo.Timeline;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
@@ -66,7 +68,7 @@ public class MemoryMapper {
                 .build();
     }
 
-    public static TimelineSliceResponse toSliceResponse(Timeline timeline) {
+    public static TimelineSliceResponse toSliceResponse(Member member, Timeline timeline) {
         List<TimelineResponse> result =
                 timeline.getTimelineContents().stream()
                         .map(TimelineResponse::mapToTimelineResponseDto)
@@ -74,6 +76,7 @@ public class MemoryMapper {
 
         return TimelineSliceResponse.builder()
                 .content(result)
+                .member(MemberSimpleResponse.from(member.getGoal()))
                 .pageSize(timeline.getPageSize())
                 .cursorRecordAt(getCursorRecordAtResponse(timeline))
                 .hasNext(timeline.isHasNext())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #160 

## 📌 작업 내용 및 특이사항
- 캘린더 조회 API에 멤버 이름, 목표 필드를 추가하였습니다.
- 타임라인 조회 API에 멤버 목표 필드를 추가하였습니다.

## 📝 참고사항
`[캘린더 조회 API 변경 사항]`
<img width="469" alt="image" src="https://github.com/user-attachments/assets/3f124587-aa35-4a1d-9afe-98607768beca">

`[타임라인 조회 API 변경 사항]`
<img width="671" alt="image" src="https://github.com/user-attachments/assets/c327419f-9e65-4f9e-8274-7c42e4b7e11f">
