### PR TITLE
fix: qa에서 발생한 오류 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
@@ -86,7 +86,7 @@ public class Memory {
 
         int totalDistance = 0;
         for (Stroke stroke : this.strokes) {
-            if (stroke.getMeter() != null) {
+            if (stroke.getMeter() != null && stroke.getMeter() != 0) {
                 totalDistance += stroke.getMeter();
             } else {
                 if (this.lane != null) {

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -23,7 +23,7 @@ public class ImageController implements ImageApi {
     public ApiResponse<?> getPresignedUrlForUploadImage(
             @RequestBody ImageNameRequest imageNameRequest) {
         List<ImageUploadResponse> imageUploadResponses =
-                imageFacade.getPresignedUrlAndSaveImages(imageNameRequest.imageNames());
+                imageFacade.getPresignedUrlAndSaveImages(imageNameRequest);
 
         return ApiResponse.success(GENERATE_PRESIGNED_URL_SUCCESS, imageUploadResponses);
     }
@@ -31,8 +31,7 @@ public class ImageController implements ImageApi {
     @PatchMapping("/memory/{memoryId}")
     public ApiResponse<?> updateImages(
             @PathVariable("memoryId") Long memoryId, @RequestBody ImageNameRequest imageNames) {
-        List<ImageUploadResponse> images =
-                imageFacade.updateImages(memoryId, imageNames.imageNames());
+        List<ImageUploadResponse> images = imageFacade.updateImages(memoryId, imageNames);
 
         return ApiResponse.success(UPDATE_AND_GET_PRESIGNED_URL_SUCCESS, images);
     }

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -1,7 +1,9 @@
 package com.depromeet.image.facade;
 
+import com.depromeet.exception.BadRequestException;
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.vo.ImagePresignedUrlVo;
+import com.depromeet.image.dto.request.ImageNameRequest;
 import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.image.dto.response.ImageUploadResponse;
 import com.depromeet.image.port.in.ImageDeleteUseCase;
@@ -10,6 +12,8 @@ import com.depromeet.image.port.in.ImageUpdateUseCase;
 import com.depromeet.image.port.in.ImageUploadUseCase;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.service.MemoryService;
+import com.depromeet.type.image.ImageErrorType;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,13 +29,22 @@ public class ImageFacade {
     private final ImageUpdateUseCase imageUpdateUseCase;
     private final ImageDeleteUseCase imageDeleteUseCase;
 
-    public List<ImageUploadResponse> getPresignedUrlAndSaveImages(List<String> imageNames) {
+    public List<ImageUploadResponse> getPresignedUrlAndSaveImages(
+            ImageNameRequest imageNameRequest) {
+        if (imageNameRequest.imageNames() == null) {
+            throw new BadRequestException(ImageErrorType.IMAGES_CANNOT_BE_EMPTY);
+        }
         List<ImagePresignedUrlVo> imagePresignedUrlVos =
-                imageUploadUseCase.getPresignedUrlAndSaveImages(imageNames);
+                imageUploadUseCase.getPresignedUrlAndSaveImages(imageNameRequest.imageNames());
         return imagePresignedUrlVos.stream().map(ImageUploadResponse::of).toList();
     }
 
-    public List<ImageUploadResponse> updateImages(Long memoryId, List<String> imageNames) {
+    public List<ImageUploadResponse> updateImages(
+            Long memoryId, ImageNameRequest imageNameRequest) {
+        List<String> imageNames = new ArrayList<>();
+        if (imageNameRequest.imageNames() != null) {
+            imageNames = imageNameRequest.imageNames();
+        }
         Memory memory = memoryService.findById(memoryId);
         List<ImagePresignedUrlVo> imagePresignedUrlVos =
                 imageUpdateUseCase.updateImages(memory, imageNames);

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
@@ -1,14 +1,12 @@
 package com.depromeet.memory.dto.response;
 
 import com.depromeet.memory.domain.MemoryDetail;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.time.LocalTime;
 import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemoryDetailResponse(
-        String item, Short heartRate, @JsonFormat(pattern = "mm:ss") LocalTime pace, Integer kcal) {
+        String item, Short heartRate, int paceMinutes, int paceSeconds, Integer kcal) {
     @Builder
     public MemoryDetailResponse {}
 
@@ -16,7 +14,8 @@ public record MemoryDetailResponse(
         return MemoryDetailResponse.builder()
                 .item(memoryDetail.getItem())
                 .heartRate(memoryDetail.getHeartRate())
-                .pace(memoryDetail.getPace())
+                .paceMinutes(memoryDetail.getPace().getMinute())
+                .paceSeconds(memoryDetail.getPace().getSecond())
                 .kcal(memoryDetail.getKcal())
                 .build();
     }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -64,13 +64,17 @@ public class MemoryResponse {
             Short lane,
             String diary) {
         // 영법 별 바퀴 수와 미터 수를 계산
-        List<StrokeResponse> resultStrokes = getResultStrokes(strokes, lane);
+        List<StrokeResponse> resultStrokes = getResultStrokes(strokes);
 
         // 기록 전체 바퀴 수와 미터 수를 계산
         Float totalLap = 0F;
         Integer totalMeter = 0;
+
         for (StrokeResponse stroke : resultStrokes) {
             totalLap += stroke.laps();
+            if (stroke.meter() == 0) {
+                totalMeter += (int) (stroke.laps() * lane);
+            }
             totalMeter += stroke.meter();
         }
 
@@ -107,26 +111,16 @@ public class MemoryResponse {
         return images.stream().map(ImageSimpleResponse::of).toList();
     }
 
-    private static List<StrokeResponse> getResultStrokes(List<Stroke> strokes, Short lane) {
+    private static List<StrokeResponse> getResultStrokes(List<Stroke> strokes) {
         return strokes.stream()
                 .map(
-                        stroke -> {
-                            if (stroke.getLaps() != null) {
-                                return StrokeResponse.builder()
+                        stroke ->
+                                StrokeResponse.builder()
                                         .strokeId(stroke.getId())
                                         .name(stroke.getName())
                                         .laps(stroke.getLaps())
-                                        .meter((short) (stroke.getLaps() * 2) * lane)
-                                        .build();
-                            } else {
-                                return StrokeResponse.builder()
-                                        .strokeId(stroke.getId())
-                                        .name(stroke.getName())
-                                        .laps((float) stroke.getMeter() / (lane * 2))
                                         .meter(stroke.getMeter())
-                                        .build();
-                            }
-                        })
+                                        .build())
                 .toList();
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -89,19 +89,19 @@ public class MemoryFacade {
 
     public TimelineSliceResponse getTimelineByMemberIdAndCursorAndDate(
             Long memberId, LocalDate cursorRecordAt, YearMonth date, boolean showNewer) {
+        Member member = memberUseCase.findById(memberId);
         Timeline timeline =
                 timelineUseCase.getTimelineByMemberIdAndCursorAndDate(
                         memberId, cursorRecordAt, date, showNewer);
-        Member member = timeline.getTimelineContents().getFirst().getMember();
 
         return MemoryMapper.toSliceResponse(member, timeline);
     }
 
     public CalendarResponse getCalendar(Long memberId, Integer year, Short month) {
         YearMonth yearMonth = YearMonth.of(year, month);
+        Member member = memberUseCase.findById(memberId);
         List<Memory> calendarMemories =
                 calendarUseCase.getCalendarByYearAndMonth(memberId, yearMonth);
-        Member member = calendarMemories.getFirst().getMember();
         return CalendarResponse.of(member, calendarMemories);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/validator/HalfFloatValidator.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/validator/HalfFloatValidator.java
@@ -8,7 +8,7 @@ public class HalfFloatValidator implements ConstraintValidator<HalfFloatCheck, F
     @Override
     public boolean isValid(Float value, ConstraintValidatorContext constraintValidatorContext) {
         if (value == null) {
-            return false;
+            return true;
         }
         return value % 0.5 == 0F;
     }

--- a/module-presentation/src/test/java/com/depromeet/image/api/ImageControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/image/api/ImageControllerTest.java
@@ -1,7 +1,6 @@
 package com.depromeet.image.api;
 
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -10,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.depromeet.config.ControllerTestConfig;
 import com.depromeet.config.mock.WithCustomMockMember;
+import com.depromeet.image.dto.request.ImageNameRequest;
 import com.depromeet.image.dto.response.ImageResponse;
 import com.depromeet.image.dto.response.ImageUploadResponse;
 import com.depromeet.image.facade.ImageFacade;
@@ -43,7 +43,8 @@ public class ImageControllerTest extends ControllerTestConfig {
         List<ImageUploadResponse> images = ImageUploadResponseDtoFixture.make(imageNames);
 
         // when
-        when(imageFacade.getPresignedUrlAndSaveImages(anyList())).thenReturn(images);
+        when(imageFacade.getPresignedUrlAndSaveImages(any(ImageNameRequest.class)))
+                .thenReturn(images);
 
         // then
         mockMvc.perform(
@@ -72,7 +73,7 @@ public class ImageControllerTest extends ControllerTestConfig {
         List<ImageUploadResponse> images = ImageUploadResponseDtoFixture.make(imageNames);
 
         // when
-        when(imageFacade.updateImages(anyLong(), anyList())).thenReturn(images);
+        when(imageFacade.updateImages(anyLong(), any(ImageNameRequest.class))).thenReturn(images);
 
         // then
         mockMvc.perform(


### PR DESCRIPTION
## 🌱 관련 이슈

- close #167 

## 📌 작업 내용 및 특이사항
- Image 등록 시 null 로 request 전송 시 IMAGES_CANNOT_BE_EMPTY 리턴하도록 수정
- image 수정 시 null로 request 전송 시 빈 배열로 간주하도록 수정
- timeline, Calendar nosuchElementException 오류 수정 (memory.getFirst() 비어있으면 nosuchElementException)
- memory등록시 stroke laps null일 때 오류 수정

## 📝 참고사항
- image등록 시 null 전송
![image](https://github.com/user-attachments/assets/ea78896a-efef-40fd-8c97-4c8fde1089fa)

- 응답 결과
![image](https://github.com/user-attachments/assets/78a4ddd3-05a2-47fe-8300-ba9bd8f36e9b)

- image 수정 시 null 전송
![image](https://github.com/user-attachments/assets/dd4c079b-abc8-48dc-86e5-4bc9f288a428)

- 응답 결과
![image](https://github.com/user-attachments/assets/04cd1bad-1177-4922-ba45-0f5de879c5ef)

- memory 등록시 stroke에서 laps 제외시 오류 수정
![image](https://github.com/user-attachments/assets/fab05435-92e8-40f8-9e84-1fdfc9aa2b6e)

- 응답 결과
![image](https://github.com/user-attachments/assets/4db1a1fc-a98f-479c-a003-5de24adff5fb)

- 타임라인/캘린더 noSuchElementException 해결

- 타임라인 응답
![image](https://github.com/user-attachments/assets/1fa822d8-2ccd-4735-8d2f-acf83d6c3f99)

- 캘린더 응답
![image](https://github.com/user-attachments/assets/6dae0575-a7ba-405c-bc61-2794d0a04d81)




