### PR TITLE
fix: 수영 기록 입력 시 다른 사람이 이전에 기록한 날짜로 기록작성 시 500에러가 나는 이슈 해결

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -11,7 +11,7 @@ public interface MemoryPersistencePort {
 
     Optional<Memory> findById(Long memoryId);
 
-    Optional<Memory> findByRecordAt(LocalDate recordAt);
+    Optional<Memory> findByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 
     Optional<Memory> update(Long memoryId, Memory memoryUpdate);
 

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -35,7 +35,7 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
     @Transactional
     public Memory save(Member writer, CreateMemoryCommand command) {
         MemoryDetail memoryDetail = getMemoryDetail(command);
-        checkMemoryAlreadyExist(command);
+        checkMemoryAlreadyExist(command, writer.getId());
 
         if (memoryDetail != null) {
             memoryDetail = memoryDetailPersistencePort.save(memoryDetail);
@@ -101,9 +101,9 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
                 .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND));
     }
 
-    private void checkMemoryAlreadyExist(CreateMemoryCommand command) {
+    private void checkMemoryAlreadyExist(CreateMemoryCommand command, Long memberId) {
         Optional<Memory> memoryByRecordAt =
-                memoryPersistencePort.findByRecordAt(command.recordAt());
+                memoryPersistencePort.findByRecordAtAndMemberId(command.recordAt(), memberId);
 
         if (memoryByRecordAt.isPresent()) {
             throw new BadRequestException(MemoryErrorType.ALREADY_CREATED);

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
@@ -42,7 +42,7 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public Optional<Memory> findByRecordAt(LocalDate recordAt) {
+    public Optional<Memory> findByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
         return Optional.empty();
     }
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryJpaRepository.java
@@ -4,7 +4,10 @@ import com.depromeet.memory.entity.MemoryEntity;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemoryJpaRepository extends JpaRepository<MemoryEntity, Long> {
-    Optional<MemoryEntity> findByRecordAt(LocalDate recordAt);
+
+    @Query("select m from MemoryEntity m where m.recordAt = :recordAt and m.member.id = :memberId")
+    Optional<MemoryEntity> findByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -65,8 +65,9 @@ public class MemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public Optional<Memory> findByRecordAt(LocalDate recordAt) {
-        Optional<MemoryEntity> nullableMemoryEntity = memoryJpaRepository.findByRecordAt(recordAt);
+    public Optional<Memory> findByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        Optional<MemoryEntity> nullableMemoryEntity =
+                memoryJpaRepository.findByRecordAtAndMemberId(recordAt, memberId);
         if (nullableMemoryEntity.isEmpty()) {
             return Optional.empty();
         }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #174

## 📌 작업 내용 및 특이사항
- 수영 기록 입력 시 다른 사람이 이전에 기록한 날짜로 기록작성 시 500에러가 나는 이슈 해결
- 자세한 사항은 이슈 참고

- 수정 이후 다른 계정으로 같은 날짜 수영 기록 등록 후 결과
![20240805](https://github.com/user-attachments/assets/6e07c2ef-c0b5-4b8b-a1bc-ab865f56c22f)
