### PR TITLE
fix: image content-type 이미지 확장자에 따라 변경

### DIFF
--- a/module-domain/src/main/java/com/depromeet/image/port/out/s3/S3ManagePort.java
+++ b/module-domain/src/main/java/com/depromeet/image/port/out/s3/S3ManagePort.java
@@ -1,7 +1,7 @@
 package com.depromeet.image.port.out.s3;
 
 public interface S3ManagePort {
-    String getPresignedUrl(String imageName);
+    String getPresignedUrl(String imageName, String contentType);
 
     void deleteImageFromS3(String imageName);
 }

--- a/module-domain/src/main/java/com/depromeet/image/service/ImageUpdateService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageUpdateService.java
@@ -78,7 +78,7 @@ public class ImageUpdateService implements ImageUpdateUseCase {
                     ImageNameUtil.createImageName(imageName, LocalDateTime.now(clock));
             String contentType = ImageNameUtil.getContentType(imageName);
 
-            String presignedUrl = s3ManagePort.getPresignedUrl(uuidImageName, imageName);
+            String presignedUrl = s3ManagePort.getPresignedUrl(uuidImageName, contentType);
             Long addedImageId = saveNewImage(imageName, uuidImageName, memory);
 
             ImagePresignedUrlVo imageUploadResponseDto =

--- a/module-domain/src/main/java/com/depromeet/image/service/ImageUpdateService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageUpdateService.java
@@ -73,12 +73,12 @@ public class ImageUpdateService implements ImageUpdateUseCase {
                     ImageNameUtil.validateImageNameIsUUID(
                             imageName); // image가 uuid 인지 확인 (기존의 이미지인지 확인)
 
-            if (isImageExist && existImagesNames.contains(imageName))
-                continue; // image가 uuid 이고 기존의 이미지에 존재하면 패스
+            if (isImageExist && existImagesNames.contains(imageName)) continue;
             String uuidImageName =
                     ImageNameUtil.createImageName(imageName, LocalDateTime.now(clock));
+            String contentType = ImageNameUtil.getContentType(imageName);
 
-            String presignedUrl = s3ManagePort.getPresignedUrl(uuidImageName);
+            String presignedUrl = s3ManagePort.getPresignedUrl(uuidImageName, imageName);
             Long addedImageId = saveNewImage(imageName, uuidImageName, memory);
 
             ImagePresignedUrlVo imageUploadResponseDto =

--- a/module-domain/src/main/java/com/depromeet/image/service/ImageUploadService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageUploadService.java
@@ -36,8 +36,11 @@ public class ImageUploadService implements ImageUploadUseCase {
 
         List<ImagePresignedUrlVo> imageResponses = new ArrayList<>();
         for (String originImageName : originImageNames) {
-            String imageName = getImageName(originImageName);
-            String imagePresignedUrl = s3ManagePort.getPresignedUrl(imageName);
+            String imageName =
+                    ImageNameUtil.createImageName(originImageName, LocalDateTime.now(clock));
+            String contentType = ImageNameUtil.getContentType(originImageName);
+
+            String imagePresignedUrl = s3ManagePort.getPresignedUrl(imageName, contentType);
 
             Long imageId = saveImage(originImageName, imageName);
             ImagePresignedUrlVo imagePresignedUrlVo =
@@ -51,13 +54,6 @@ public class ImageUploadService implements ImageUploadUseCase {
         if (originImageNames.isEmpty()) {
             throw new BadRequestException(ImageErrorType.IMAGES_CANNOT_BE_EMPTY);
         }
-    }
-
-    private String getImageName(String originImageName) {
-        if (originImageName == null || originImageName.equals("")) {
-            throw new BadRequestException(ImageErrorType.INVALID_IMAGE_NAME);
-        }
-        return ImageNameUtil.createImageName(originImageName, LocalDateTime.now(clock));
     }
 
     private Long saveImage(String originImageName, String imageNames) {

--- a/module-domain/src/test/java/com/depromeet/mock/FakeS3ImageManager.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeS3ImageManager.java
@@ -4,7 +4,7 @@ import com.depromeet.image.port.out.s3.S3ManagePort;
 
 public class FakeS3ImageManager implements S3ManagePort {
     @Override
-    public String getPresignedUrl(String imageName) {
+    public String getPresignedUrl(String imageName, String contentType) {
         return "http://presigned-url/" + imageName;
     }
 

--- a/module-domain/src/test/java/com/depromeet/service/ImageServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/ImageServiceTest.java
@@ -82,11 +82,12 @@ class ImageServiceTest {
         for (String originImageName : originImageNames) {
             String imageName =
                     ImageNameUtil.createImageName(originImageName, LocalDateTime.now(clock));
+            String contentType = ImageNameUtil.getContentType(originImageName);
 
             ImagePresignedUrlVo imagePresignedUrlVo =
                     ImagePresignedUrlVo.builder()
                             .imageName(originImageName)
-                            .presignedUrl(s3ImageManager.getPresignedUrl(imageName))
+                            .presignedUrl(s3ImageManager.getPresignedUrl(imageName, contentType))
                             .build();
             expectedImagePresignedUrlVos.add(imagePresignedUrlVo);
         }

--- a/module-independent/src/main/java/com/depromeet/constant/ImageTypeConstant.java
+++ b/module-independent/src/main/java/com/depromeet/constant/ImageTypeConstant.java
@@ -1,0 +1,37 @@
+package com.depromeet.constant;
+
+import com.depromeet.exception.BadRequestException;
+import com.depromeet.type.image.ImageErrorType;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public enum ImageTypeConstant {
+    JPG("jpg", "image/jpeg"),
+    JPEG("jpeg", "image/jpeg"),
+    PNG("png", "image/png"),
+    WEBP("webp", "image/webp");
+
+    private final String extensionType;
+    private final String contentType;
+
+    ImageTypeConstant(String extensionType, String contentType) {
+        this.extensionType = extensionType;
+        this.contentType = contentType;
+    }
+
+    public static String fromExtensionType(String extensionType) {
+        log.info("extensionType: {}", extensionType);
+        if (extensionType == null) {
+            throw new BadRequestException(ImageErrorType.IMAGE_TYPE_NULL);
+        }
+
+        return Arrays.stream(ImageTypeConstant.values())
+                .filter(extension -> extension.extensionType.equals(extensionType))
+                .findAny()
+                .orElseThrow(() -> new BadRequestException(ImageErrorType.INVALID_IMAGE_TYPE))
+                .getContentType();
+    }
+}

--- a/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
@@ -16,7 +16,7 @@ public enum CommonErrorType implements ErrorType {
     IO("COMMON_11", "I/O 예외가 발생했습니다"),
     NULL("COMMON_12", "객체가 null 인 상태에서 접근하였습니다"),
     NO_SUCH_ELEMENT("COMMON_13", "요소가 존재하지 않습니다");
-  
+
     private final String code;
     private final String message;
 

--- a/module-independent/src/main/java/com/depromeet/type/image/ImageErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/image/ImageErrorType.java
@@ -6,7 +6,9 @@ public enum ImageErrorType implements ErrorType {
     NOT_FOUND("IMAGE_1", "이미지가 존재하지 않습니다"),
     INVALID_IMAGE_NAME("IMAGE_2", "이미지 이름이 유효하지 않습니다"),
     IMAGES_CANNOT_BE_NULL("IMAGE_3", "이미지 리스트가 존재하지 않습니다"),
-    IMAGES_CANNOT_BE_EMPTY("IMAGE_4", "이미지 리스트가 비어있습니다");
+    IMAGES_CANNOT_BE_EMPTY("IMAGE_4", "이미지 리스트가 비어있습니다"),
+    INVALID_IMAGE_TYPE("IMAGE_5", "이미지 형식이 올바르지 않습니다"),
+    IMAGE_TYPE_NULL("IMAGE_6", "이미지 형식이 비어있습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/util/ImageNameUtil.java
+++ b/module-independent/src/main/java/com/depromeet/util/ImageNameUtil.java
@@ -1,22 +1,36 @@
 package com.depromeet.util;
 
+import com.depromeet.constant.ImageTypeConstant;
+import com.depromeet.exception.BadRequestException;
+import com.depromeet.type.image.ImageErrorType;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 public class ImageNameUtil {
-    public static String createImageName(String originalImageName, LocalDateTime localDateTime) {
-        int extensionIdx = originalImageName.lastIndexOf(".") + 1;
-        String extension = originalImageName.substring(extensionIdx).toLowerCase();
+    public static String createImageName(String originImageName, LocalDateTime localDateTime) {
+        if (originImageName == null || originImageName.equals("")) {
+            throw new BadRequestException(ImageErrorType.INVALID_IMAGE_NAME);
+        }
+
+        int extensionIdx = originImageName.lastIndexOf(".") + 1;
+        String extension = originImageName.substring(extensionIdx).toLowerCase();
 
         String localDateTimeFormat =
                 localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS"));
 
-        String imageName = originalImageName + localDateTimeFormat;
+        String imageName = originImageName + localDateTimeFormat;
 
         UUID imageUUID = UUID.nameUUIDFromBytes(imageName.getBytes());
 
         return imageUUID + "." + extension;
+    }
+
+    public static String getContentType(String originalImageName) {
+        int extensionIdx = originalImageName.lastIndexOf(".") + 1;
+        String extension = originalImageName.substring(extensionIdx).toLowerCase();
+
+        return ImageTypeConstant.fromExtensionType(extension);
     }
 
     public static boolean validateImageNameIsUUID(String imageName) {

--- a/module-infrastructure/object-storage/src/main/java/com/depromeet/manage/S3ImageManager.java
+++ b/module-infrastructure/object-storage/src/main/java/com/depromeet/manage/S3ImageManager.java
@@ -22,12 +22,12 @@ public class S3ImageManager implements S3ManagePort {
     private String bucketName;
 
     @Override
-    public String getPresignedUrl(String imageName) {
+    public String getPresignedUrl(String imageName, String contentType) {
         PutObjectRequest putObjectRequest =
                 PutObjectRequest.builder()
                         .bucket(bucketName)
                         .key(imageName)
-                        .contentType("image/webp")
+                        .contentType(contentType)
                         .build();
 
         PutObjectPresignRequest putObjectPresignRequest =

--- a/module-infrastructure/object-storage/src/main/java/com/depromeet/manage/S3ImageManager.java
+++ b/module-infrastructure/object-storage/src/main/java/com/depromeet/manage/S3ImageManager.java
@@ -24,7 +24,11 @@ public class S3ImageManager implements S3ManagePort {
     @Override
     public String getPresignedUrl(String imageName) {
         PutObjectRequest putObjectRequest =
-                PutObjectRequest.builder().bucket(bucketName).key(imageName).build();
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(imageName)
+                        .contentType("image/webp")
+                        .build();
 
         PutObjectPresignRequest putObjectPresignRequest =
                 PutObjectPresignRequest.builder()


### PR DESCRIPTION
## 🌱 관련 이슈

- close #177 

## 📌 작업 내용 및 특이사항
- 현재 프론트 측에서 webp 이미지 업로드 후 조회 시 이미지가 깨지는 현상 발생
- 추측되는 원인들 중 하나로 content-type 이 설정 되지 않아 발생한 문제라고 생각
- image content type 이미지 확장자에 따라 변경

----------
webp 이미지 저장 결과
![이미지저장20240806](https://github.com/user-attachments/assets/02480eca-85df-4e0f-bd60-47155d791a4c)
![이미지조회20240806](https://github.com/user-attachments/assets/d2d551b8-d830-43c9-8951-74dc4486e69b)

png 이미지 저장 결과
![이미지저장png20240806](https://github.com/user-attachments/assets/894125e8-b593-4466-ae03-1f8d5995782e)
![이미지저장png20240806조회](https://github.com/user-attachments/assets/70ddae80-4ef8-4be4-b106-374587c1341b)

