### PR TITLE
fix: 수영기록 기록 시 laps 0으로 입력하고 meter를 0이상으로 입력하는 경우 조회 시 laps와 meter 전부가 0으로 조회 되는 이슈 해결

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -124,7 +124,7 @@ public class MemoryResponse {
         Float totalLap = 0F;
         Integer totalMeter = 0;
         for (StrokeResponse stroke : resultStrokes) {
-            if (stroke.laps() != null) {
+            if (stroke.laps() != null && stroke.laps() != 0) {
                 totalLap += stroke.laps();
             }
             if (stroke.meter() != null) {

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -169,7 +169,7 @@ public class MemoryResponse {
         return strokes.stream()
                 .map(
                         stroke -> {
-                            if (stroke.getLaps() != null) {
+                            if (stroke.getLaps() != null && stroke.getLaps() != 0) {
                                 return StrokeResponse.builder()
                                         .strokeId(stroke.getId())
                                         .name(stroke.getName())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #182 

## 📌 작업 내용 및 특이사항
- 수영기록 등록시 stroke에서 laps = 0, meter > 0으로 등록한 후, 조회시 laps와 meter 둘다 0으로 조회되는 이슈가 있었습니다. (db에는 정상적으로 저장됨)
- 프론트 측에서는 laps 값이 비어서 오는 경우, laps = 0으로 요청값을 설정하여 전달해주는데, 이때 if(stroke.getLaps() != null) 조건문을 통과하여 발생한 문제였습니다.
- 조건문을 `stroke.getLaps() != null && stroke.getLaps() != 0` 로 변경하여 해결하였습니다.

## 📝 참고사항
- meter = 0으로 등록하는 경우
![수영기록meter0](https://github.com/user-attachments/assets/92f8b39e-c87c-4be9-8d4b-8e632ac058af)
![수영기록meter0조회](https://github.com/user-attachments/assets/fe2c7ff5-5b81-4436-82e6-3bf24d5d63c5)

- laps = 0으로 등록하는 경우
![수영기록laps0](https://github.com/user-attachments/assets/8a78ffab-a198-4a4c-bdb2-0266ce4087de)
![수영기록laps0조회](https://github.com/user-attachments/assets/e5b8d937-1f87-4de5-ae2d-d997e78a8236)

