### PR TITLE
feat: 계정 탈퇴 및 소셜계정 연결 끊기 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
@@ -7,4 +7,6 @@ public interface SocialUseCase {
     AccountProfileResponse getGoogleAccountProfile(String code, String origin);
 
     KakaoAccountProfile getKakaoAccountProfile(String code, String origin);
+
+    void revokeAccount(String accountType);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/GooglePort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/GooglePort.java
@@ -4,4 +4,6 @@ import com.depromeet.dto.auth.AccountProfileResponse;
 
 public interface GooglePort {
     AccountProfileResponse getGoogleAccountProfile(String code, String origin);
+
+    void revokeAccount(String providerId);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/KakaoPort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/KakaoPort.java
@@ -4,4 +4,6 @@ import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 
 public interface KakaoPort {
     KakaoAccountProfile getKakaoAccountProfile(final String code, String origin);
+
+    void revokeAccount(String providerId);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/persistence/SocialRedisPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/persistence/SocialRedisPersistencePort.java
@@ -1,0 +1,15 @@
+package com.depromeet.auth.port.out.persistence;
+
+public interface SocialRedisPersistencePort {
+    void setATData(String providerId, String accessToken, Long expireTime);
+
+    String getATData(String providerId);
+
+    void deleteATData(String providerId);
+
+    void setRTData(String providerId, String refreshToken, Long expireTime);
+
+    String getRTData(String providerId);
+
+    void deleteRTData(String providerId);
+}

--- a/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
+++ b/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
@@ -5,6 +5,8 @@ import com.depromeet.auth.port.out.GooglePort;
 import com.depromeet.auth.port.out.KakaoPort;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.dto.auth.AccountProfileResponse;
+import com.depromeet.exception.NotFoundException;
+import com.depromeet.type.auth.AuthErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -24,5 +26,19 @@ public class SocialService implements SocialUseCase {
     @Override
     public KakaoAccountProfile getKakaoAccountProfile(String code, String origin) {
         return kakaoPort.getKakaoAccountProfile(code, origin);
+    }
+
+    @Override
+    public void revokeAccount(String accountType) {
+        String[] type = accountType.split(" ");
+        if (type.length < 2) {
+            throw new NotFoundException(AuthErrorType.NOT_FOUND);
+        }
+        String providerId = type[1];
+        if (accountType.startsWith("kakao")) {
+            kakaoPort.revokeAccount(providerId);
+        } else if (accountType.startsWith("google")) {
+            googlePort.revokeAccount(providerId);
+        }
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
@@ -7,4 +7,6 @@ public interface MemberUseCase {
     Member findById(Long id);
 
     Member findOrCreateMemberBy(SocialMemberCommand command);
+
+    void deleteById(Long id);
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
@@ -15,4 +15,6 @@ public interface MemberPersistencePort {
     Optional<Member> updateName(Long memberId, String name);
 
     Optional<Member> findByProviderId(String providerId);
+
+    void deleteById(Long id);
 }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.depromeet.member.service;
 
+import com.depromeet.auth.port.out.persistence.RefreshRedisPersistencePort;
 import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService implements MemberUseCase, GoalUpdateUseCase, NameUpdateUseCase {
     private final MemberPersistencePort memberPersistencePort;
+    private final RefreshRedisPersistencePort refreshRedisPersistencePort;
 
     @Override
     @Transactional(readOnly = true)
@@ -44,6 +46,13 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, NameUpda
                                             .build();
                             return memberPersistencePort.save(member);
                         });
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        findById(id);
+        memberPersistencePort.deleteById(id);
+        refreshRedisPersistencePort.deleteData(id);
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemberRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemberRepository.java
@@ -65,4 +65,9 @@ public class FakeMemberRepository implements MemberPersistencePort {
     public Optional<Member> findByProviderId(String providerId) {
         return data.stream().filter(member -> member.getProviderId().equals(providerId)).findAny();
     }
+
+    @Override
+    public void deleteById(Long id) {
+        data.removeIf(member -> member.getId().equals(id));
+    }
 }

--- a/module-domain/src/test/java/com/depromeet/service/MemberServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/MemberServiceTest.java
@@ -1,16 +1,19 @@
 package com.depromeet.service;
 
+import com.depromeet.auth.port.out.persistence.RefreshRedisPersistencePort;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberRole;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.depromeet.member.service.MemberService;
 import com.depromeet.mock.FakeMemberRepository;
+import com.depromeet.mock.FakeRefreshRedisRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MemberServiceTest {
     private MemberPersistencePort fakeMemberRepository;
+    private RefreshRedisPersistencePort fakeRefreshRedisPersistencePort;
 
     private MemberService memberService;
 
@@ -20,6 +23,7 @@ class MemberServiceTest {
     @BeforeEach
     void init() {
         fakeMemberRepository = new FakeMemberRepository();
+        fakeRefreshRedisPersistencePort = new FakeRefreshRedisRepository();
 
         // Member create
         member =
@@ -31,7 +35,7 @@ class MemberServiceTest {
                         .build();
         fakeMemberRepository.save(member);
 
-        memberService = new MemberService(fakeMemberRepository);
+        memberService = new MemberService(fakeMemberRepository, fakeRefreshRedisPersistencePort);
     }
 
     @Test

--- a/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
@@ -16,7 +16,11 @@ public enum AuthErrorType implements ErrorType {
     JWT_TOKEN_PREFIX("AUTH_11", "JWT 토큰이 Bearer로 시작하지 않습니다"),
     INVALID_JWT_TOKEN("AUTH_12", "유효하지 않은 JWT 토큰입니다"),
     INVALID_JWT_REFRESH_REQUEST("AUTH_14", "JWT REFRESH 토큰 재발급 요청 URL이 올바르지 않습니다"),
-    INVALID_JWT_ACCESS_REQUEST("AUTH_15", "JWT ACCESS 토큰 사용 요청 URL이 올바르지 않습니다");
+    INVALID_JWT_ACCESS_REQUEST("AUTH_15", "JWT ACCESS 토큰 사용 요청 URL이 올바르지 않습니다"),
+    OAUTH_ACCESS_TOKEN_NOT_FOUND("AUTH_16", "OAUTH ACCESS 토큰을 찾을 수 없습니다"),
+    INVALID_OAUTH_ACCESS_TOKEN("AUTH_17", "OAUTH ACCESS 토큰이 올바르지 않습니다"),
+    OAUTH_REFRESH_TOKEN_NOT_FOUND("AUTH_18", "OAUTH REFRESH 토큰을 찾을 수 없습니다"),
+    REVOKE_GOOGLE_ACCOUNT_FAILED("AUTH_19", "GOOGLE 계정 연결 끊기에 실패하였습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/auth/AuthSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/auth/AuthSuccessType.java
@@ -5,7 +5,8 @@ import com.depromeet.type.SuccessType;
 public enum AuthSuccessType implements SuccessType {
     LOGIN_SUCCESS("AUTH_1", "로그인에 성공하였습니다"),
     REISSUE_ACCESS_TOKEN_SUCCESS("AUTH_2", "JWT ACCESS 토큰 발급에 성공하였습니다"),
-    LOGOUT_SUCCESS("AUTH_3", "로그아웃에 성공하였습니다");
+    LOGOUT_SUCCESS("AUTH_3", "로그아웃에 성공하였습니다"),
+    DELETE_ACCOUNT_SUCCESS("AUTH_4", "회원 탈퇴에 성공하였습니다");
 
     private final String code;
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
@@ -45,4 +45,9 @@ public class MemberRepository implements MemberPersistencePort {
     public Optional<Member> findByProviderId(String providerId) {
         return memberJpaRepository.findByProviderId(providerId).map(MemberEntity::toModel);
     }
+
+    @Override
+    public void deleteById(Long id) {
+        memberJpaRepository.deleteById(id);
+    }
 }

--- a/module-infrastructure/persistence-redis/src/main/java/com/depromeet/redis/repository/SocialRedisRepository.java
+++ b/module-infrastructure/persistence-redis/src/main/java/com/depromeet/redis/repository/SocialRedisRepository.java
@@ -1,0 +1,47 @@
+package com.depromeet.redis.repository;
+
+import com.depromeet.auth.port.out.persistence.SocialRedisPersistencePort;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SocialRedisRepository implements SocialRedisPersistencePort {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void setATData(String providerId, String accessToken, Long expireTime) {
+        redisTemplate
+                .opsForValue()
+                .set("AT(oauth2):" + providerId, accessToken, expireTime, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public String getATData(String providerId) {
+        return redisTemplate.opsForValue().get("AT(oauth2):" + providerId);
+    }
+
+    @Override
+    public void deleteATData(String providerId) {
+        redisTemplate.delete("AT(oauth2):" + providerId);
+    }
+
+    @Override
+    public void setRTData(String providerId, String refreshToken, Long expireTime) {
+        redisTemplate
+                .opsForValue()
+                .set("RT(oauth2):" + providerId, refreshToken, expireTime, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public String getRTData(String providerId) {
+        return redisTemplate.opsForValue().get("RT(oauth2):" + providerId);
+    }
+
+    @Override
+    public void deleteRTData(String providerId) {
+        redisTemplate.delete("RT(oauth2):" + providerId);
+    }
+}

--- a/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/GoogleAccessTokenResponse.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/GoogleAccessTokenResponse.java
@@ -5,4 +5,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record GoogleAccessTokenResponse(
-        String accessToken, Integer expiresIn, String scope, String tokenType, String idToken) {}
+        String accessToken,
+        Integer expiresIn,
+        String scope,
+        String tokenType,
+        String idToken,
+        String refreshToken) {}

--- a/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/KakaoRevokeResponse.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/KakaoRevokeResponse.java
@@ -1,0 +1,3 @@
+package com.depromeet.oauth.dto.response;
+
+public record KakaoRevokeResponse(Long id) {}

--- a/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/KakaoTokenInfoResponse.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/KakaoTokenInfoResponse.java
@@ -1,0 +1,3 @@
+package com.depromeet.oauth.dto.response;
+
+public record KakaoTokenInfoResponse(Long id, Integer expiresIn, Integer appId) {}

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
@@ -1,7 +1,9 @@
 package com.depromeet.util;
 
 import com.depromeet.auth.port.out.GooglePort;
+import com.depromeet.auth.port.out.persistence.SocialRedisPersistencePort;
 import com.depromeet.dto.auth.AccountProfileResponse;
+import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.oauth.dto.request.GoogleAccessTokenRequest;
@@ -9,6 +11,7 @@ import com.depromeet.type.auth.AuthErrorType;
 import com.depromeet.type.common.CommonErrorType;
 import com.google.api.client.auth.oauth2.TokenResponseException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
+import com.google.api.client.googleapis.auth.oauth2.GoogleRefreshTokenRequest;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
@@ -16,9 +19,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -44,25 +45,86 @@ public class GoogleClient implements GooglePort {
     @Value("${url.profile}")
     private String profileUrl;
 
+    @Value("${jwt.access-token-expiration-time}")
+    private Long ATExpireTime;
+
+    @Value("${jwt.refresh-token-expiration-time}")
+    private Long RTExpireTime;
+
     private final RestTemplate restTemplate;
+    private final SocialRedisPersistencePort socialRedisPersistencePort;
 
     public AccountProfileResponse getGoogleAccountProfile(final String code, String origin) {
-        final String accessToken = requestAccessToken(code, origin);
-        return requestGoogleAccountProfile(accessToken);
+        final GoogleTokenResponse googleTokenResponse = requestAccessToken(code, origin);
+        String accessToken = googleTokenResponse.getAccessToken();
+        final AccountProfileResponse response = requestGoogleAccountProfile(accessToken);
+
+        socialRedisPersistencePort.setATData(response.id(), accessToken, ATExpireTime);
+        socialRedisPersistencePort.setRTData(
+                response.id(), googleTokenResponse.getRefreshToken(), RTExpireTime);
+
+        return response;
     }
 
-    private String requestAccessToken(String code, String origin) {
+    @Override
+    public void revokeAccount(String providerId) {
+        // refresh token 가져오기
+        String refreshToken = socialRedisPersistencePort.getRTData(providerId);
+        if (refreshToken.isEmpty() || refreshToken.isBlank()) {
+            // refresh token 없으면 오류 (재로그인 필요)
+            throw new NotFoundException(AuthErrorType.OAUTH_ACCESS_TOKEN_NOT_FOUND);
+        }
+        // refresh token 으로 access token 재발급 하기
+        GoogleTokenResponse googleTokenResponse = reissueAccessToken(refreshToken);
+        // access token 으로 revoke 신청하기
+        String accessToken = googleTokenResponse.getAccessToken();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<?> response =
+                restTemplate.exchange(
+                        "https://oauth2.googleapis.com/revoke?token=" + accessToken,
+                        HttpMethod.POST,
+                        entity,
+                        Object.class);
+        if (response.getStatusCode().equals(HttpStatus.BAD_REQUEST)) {
+            throw new BadRequestException(AuthErrorType.REVOKE_GOOGLE_ACCOUNT_FAILED);
+        }
+        // redis oauth access token, refresh token 삭제
+        socialRedisPersistencePort.deleteATData(providerId);
+        socialRedisPersistencePort.deleteRTData(providerId);
+    }
+
+    private GoogleTokenResponse reissueAccessToken(String refreshToken) {
         try {
-            GoogleTokenResponse response =
-                    new GoogleAuthorizationCodeTokenRequest(
-                                    new NetHttpTransport(),
-                                    new GsonFactory(),
-                                    clientId,
-                                    clientSecret,
-                                    code,
-                                    origin + redirectUri)
-                            .execute();
-            return response.getAccessToken();
+            return new GoogleRefreshTokenRequest(
+                            new NetHttpTransport(),
+                            new GsonFactory(),
+                            refreshToken,
+                            clientId,
+                            clientSecret)
+                    .execute();
+        } catch (TokenResponseException e) {
+            if (e.getDetails() != null) {
+                throw new NotFoundException(AuthErrorType.NOT_FOUND);
+            } else {
+                throw new InternalServerException(AuthErrorType.LOGIN_FAILED);
+            }
+        } catch (IOException e) {
+            throw new InternalServerException(CommonErrorType.IO);
+        }
+    }
+
+    private GoogleTokenResponse requestAccessToken(String code, String origin) {
+        try {
+            return new GoogleAuthorizationCodeTokenRequest(
+                            new NetHttpTransport(),
+                            new GsonFactory(),
+                            clientId,
+                            clientSecret,
+                            code,
+                            origin + redirectUri)
+                    .execute();
         } catch (TokenResponseException e) {
             if (e.getDetails() != null) {
                 throw new NotFoundException(AuthErrorType.NOT_FOUND);

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
@@ -70,7 +70,7 @@ public class GoogleClient implements GooglePort {
     public void revokeAccount(String providerId) {
         // refresh token 가져오기
         String refreshToken = socialRedisPersistencePort.getRTData(providerId);
-        if (refreshToken.isEmpty() || refreshToken.isBlank()) {
+        if (refreshToken == null || refreshToken.isEmpty() || refreshToken.isBlank()) {
             // refresh token 없으면 오류 (재로그인 필요)
             throw new NotFoundException(AuthErrorType.OAUTH_ACCESS_TOKEN_NOT_FOUND);
         }

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/KakaoClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/KakaoClient.java
@@ -76,7 +76,7 @@ public class KakaoClient implements KakaoPort {
             // access token 만료되었으면 refresh token 가져오기
             String refreshToken = socialRedisPersistencePort.getRTData(providerId);
             // refresh token 없으면 오류 (재로그인 필요)
-            if (refreshToken == null) {
+            if (refreshToken == null || refreshToken.isEmpty() || refreshToken.isBlank()) {
                 throw new NotFoundException(AuthErrorType.OAUTH_REFRESH_TOKEN_NOT_FOUND);
             }
             // refresh token 으로 access token 재발급 하기

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/KakaoClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/KakaoClient.java
@@ -1,15 +1,17 @@
 package com.depromeet.util;
 
 import com.depromeet.auth.port.out.KakaoPort;
+import com.depromeet.auth.port.out.persistence.SocialRedisPersistencePort;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.exception.NotFoundException;
+import com.depromeet.exception.UnauthorizedException;
 import com.depromeet.oauth.dto.response.KakaoAccessTokenResponse;
 import com.depromeet.oauth.dto.response.KakaoAccountProfileResponse;
+import com.depromeet.oauth.dto.response.KakaoRevokeResponse;
+import com.depromeet.oauth.dto.response.KakaoTokenInfoResponse;
 import com.depromeet.type.auth.AuthErrorType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -39,18 +41,98 @@ public class KakaoClient implements KakaoPort {
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String profileUrl;
 
+    @Value("${jwt.access-token-expiration-time}")
+    private Long ATExpireTime;
+
+    @Value("${jwt.refresh-token-expiration-time}")
+    private Long RTExpireTime;
+
     private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final SocialRedisPersistencePort socialRedisPersistencePort;
 
     public KakaoAccountProfile getKakaoAccountProfile(final String code, String origin) {
-        final String accessToken = requestKakaoAccessToken(code, origin);
+        final KakaoAccessTokenResponse kakaoTokenResponse = requestKakaoAccessToken(code, origin);
+        String accessToken = kakaoTokenResponse.accessToken();
         KakaoAccountProfileResponse response = requestKakaoAccountProfile(accessToken);
+
+        socialRedisPersistencePort.setATData(response.getId(), accessToken, ATExpireTime);
+        socialRedisPersistencePort.setRTData(
+                response.getId(), kakaoTokenResponse.refreshToken(), RTExpireTime);
 
         return KakaoAccountProfile.of(
                 response.getId(), response.getEmail(), response.getNickname());
     }
 
-    private String requestKakaoAccessToken(final String code, String origin) {
+    @Override
+    public void revokeAccount(String providerId) {
+        // redis 에서 access token 가져오기
+        String accessToken = socialRedisPersistencePort.getATData(providerId);
+        if (accessToken.isEmpty() || accessToken.isBlank()) {
+            throw new NotFoundException(AuthErrorType.OAUTH_ACCESS_TOKEN_NOT_FOUND);
+        }
+        // access token 유효성 검사
+        ResponseEntity<KakaoTokenInfoResponse> tokenInfoResponse = validateAccessToken(accessToken);
+        if (tokenInfoResponse.getStatusCode().equals(HttpStatus.UNAUTHORIZED)) {
+            // access token 만료되었으면 refresh token 가져오기
+            String refreshToken = socialRedisPersistencePort.getRTData(providerId);
+            // refresh token 없으면 오류 (재로그인 필요)
+            if (refreshToken == null) {
+                throw new NotFoundException(AuthErrorType.OAUTH_REFRESH_TOKEN_NOT_FOUND);
+            }
+            // refresh token 으로 access token 재발급 하기
+            KakaoAccessTokenResponse kakaoTokenResponse = reissueKakaoAccessToken(refreshToken);
+            accessToken = kakaoTokenResponse.accessToken();
+        }
+        KakaoTokenInfoResponse tokenInfo = tokenInfoResponse.getBody();
+        if (tokenInfo == null) {
+            throw new UnauthorizedException(AuthErrorType.INVALID_OAUTH_ACCESS_TOKEN);
+        }
+        // access token 으로 revoke 신청하기
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("target_id_type", "user_id");
+        body.add("target_id", tokenInfo.id().toString());
+        final HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+        restTemplate.exchange(
+                "https://kapi.kakao.com/v1/user/unlink",
+                HttpMethod.POST,
+                entity,
+                KakaoRevokeResponse.class);
+        // redis oauth access token, refresh token 삭제
+        socialRedisPersistencePort.deleteATData(providerId);
+        socialRedisPersistencePort.deleteRTData(providerId);
+    }
+
+    private KakaoAccessTokenResponse reissueKakaoAccessToken(String refreshToken) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "refresh_token");
+        body.add("client_id", clientId);
+        body.add("refresh_token", refreshToken);
+        body.add("client_secret", clientSecret);
+        final HttpEntity<MultiValueMap<String, String>> httpEntity =
+                new HttpEntity<>(body, headers);
+        return restTemplate.postForObject(
+                accessTokenUrl, httpEntity, KakaoAccessTokenResponse.class);
+    }
+
+    private ResponseEntity<KakaoTokenInfoResponse> validateAccessToken(String accessToken) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        return restTemplate.exchange(
+                "https://kapi.kakao.com/v1/user/access_token_info",
+                HttpMethod.GET,
+                entity,
+                KakaoTokenInfoResponse.class);
+    }
+
+    private KakaoAccessTokenResponse requestKakaoAccessToken(final String code, String origin) {
         final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
         final HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
@@ -63,12 +145,8 @@ public class KakaoClient implements KakaoPort {
         body.add("grant_type", grantType);
         final HttpEntity<MultiValueMap<String, String>> httpEntity =
                 new HttpEntity<>(body, headers);
-        KakaoAccessTokenResponse response =
-                restTemplate.postForObject(
-                        accessTokenUrl, httpEntity, KakaoAccessTokenResponse.class);
-        return Optional.ofNullable(response)
-                .orElseThrow(() -> new NotFoundException(AuthErrorType.NOT_FOUND))
-                .accessToken();
+        return restTemplate.postForObject(
+                accessTokenUrl, httpEntity, KakaoAccessTokenResponse.class);
     }
 
     private KakaoAccountProfileResponse requestKakaoAccountProfile(final String accessToken) {

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
@@ -5,6 +5,7 @@ import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
 import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.member.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,4 +28,7 @@ public interface AuthApi {
     @Operation(summary = "Access 토큰 재발급 요청")
     ApiResponse<JwtAccessTokenResponse> reissueAccessToken(
             @RequestHeader("Authorization") String refreshToken);
+
+    @Operation(summary = "회원 탈퇴")
+    ApiResponse<?> deleteAccount(@LoginMember Long memberId);
 }

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -7,6 +7,7 @@ import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.auth.facade.AuthFacade;
 import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.auth.AuthSuccessType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -15,11 +16,10 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/login")
 public class AuthController implements AuthApi {
     public final AuthFacade authFacade;
 
-    @PostMapping("/google")
+    @PostMapping("/login/google")
     @Logging(item = "Auth", action = "POST")
     public ApiResponse<JwtTokenResponse> loginByGoogle(
             @Valid @RequestBody final GoogleLoginRequest request,
@@ -29,7 +29,7 @@ public class AuthController implements AuthApi {
                 AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByGoogle(request, origin));
     }
 
-    @PostMapping("/kakao")
+    @PostMapping("/login/kakao")
     @Logging(item = "Auth", action = "POST")
     public ApiResponse<JwtTokenResponse> loginByKakao(
             @Valid @RequestBody final KakaoLoginRequest request,
@@ -39,13 +39,20 @@ public class AuthController implements AuthApi {
                 AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request, origin));
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/login/refresh")
     @Logging(item = "Auth", action = "POST")
     public ApiResponse<JwtAccessTokenResponse> reissueAccessToken(
             @RequestHeader("Authorization") String refreshToken) {
         return ApiResponse.success(
                 AuthSuccessType.REISSUE_ACCESS_TOKEN_SUCCESS,
                 authFacade.getReissuedAccessToken(refreshToken));
+    }
+
+    @DeleteMapping("/auth/delete")
+    @Logging(item = "Auth", action = "DELETE")
+    public ApiResponse<?> deleteAccount(@LoginMember Long memberId) {
+        authFacade.deleteAccount(memberId);
+        return ApiResponse.success(AuthSuccessType.DELETE_ACCOUNT_SUCCESS);
     }
 
     private static String getOrigin(HttpServletRequest httpServletRequest) {

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -66,4 +66,11 @@ public class AuthFacade {
         AccessTokenInfo accessTokenInfo = createTokenUseCase.generateAccessToken(refreshToken);
         return JwtAccessTokenResponse.of(accessTokenInfo);
     }
+
+    public void deleteAccount(Long memberId) {
+        Member member = memberUseCase.findById(memberId);
+        String accountType = member.getProviderId();
+        socialUseCase.revokeAccount(accountType);
+        memberUseCase.deleteById(memberId);
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #181

## 📌 작업 내용 및 특이사항
- 계정 탈퇴 및 소셜계정 연결 끊기를 구현하였습니다.
- 소셜계정 연결을 끊으려면 소셜서비스에서 제공하는 AT, RT를 사용해야 하므로 기억해 두어야 합니다.
- AT, RT는 redis에 저장하도록 하였습니다.
- AT, RT의 유효기간은 서버 자체 JWT AT, RT와 동일하도록 설정하였습니다.
- 서버 자체 JWT의 유효기간이 지나면 재로그인이 진행되고, 이때 OAuth AT, RT도 갱신되기 때문입니다.
- 데이터베이스의 변화는 없습니다.
- 클라이언트에서 code를 받을 때 설정해야 하는 query parameter가 있습니다.
- 카카오 : `&prompt=select_account` -> 로그인 시 카카오 계정 이메일, 비밀번호를 입력하는 창을 띄웁니다.
- 구글 : `&prompt=select_account&access_type=offline` -> 로그인 시 구글 계정을 선택하는 창을 띄웁니다. (구글 계정이 하나인 경우에는 prompt=select_account를 하지 않으면 자동으로 창이 넘어갑니다) `access_type=offline`이 있어야 매번 RT를 발급 받을 수 있습니다.

## 📝 참고사항
- 구글, 카카오 계정 탈퇴 및 연결 끊기가 잘 수행되는 것을 확인하였습니다.
<img width="841" alt="Screenshot 2024-08-07 at 14 58 36" src="https://github.com/user-attachments/assets/fc52ab2a-4234-4e95-914f-47d6f5073d18">
<img width="375" alt="Screenshot 2024-08-07 at 15 11 33" src="https://github.com/user-attachments/assets/4b987a42-d9be-44d9-b2b6-25c9d06c794f">
<img width="501" alt="Screenshot 2024-08-07 at 15 14 20" src="https://github.com/user-attachments/assets/f93493ea-f040-45a6-8df5-9b9bb6bc78b5">