### PR TITLE
feat: 로그인 성공 시 이름 반환 및 성별 수정 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/domain/Member.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/Member.java
@@ -11,16 +11,24 @@ public class Member {
     private MemberRole role;
     private String providerId;
     private Integer goal;
+    private MemberGender gender;
 
     @Builder
     public Member(
-            Long id, String name, String email, MemberRole role, String providerId, Integer goal) {
+            Long id,
+            String name,
+            String email,
+            MemberRole role,
+            String providerId,
+            Integer goal,
+            MemberGender gender) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.role = role;
         this.providerId = providerId;
         this.goal = goal;
+        this.gender = gender;
     }
 
     public Member updateGoal(Integer goal) {
@@ -30,6 +38,11 @@ public class Member {
 
     public Member updateName(String name) {
         this.name = name;
+        return this;
+    }
+
+    public Member updateGender(MemberGender gender) {
+        this.gender = gender;
         return this;
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/domain/MemberGender.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/MemberGender.java
@@ -1,0 +1,27 @@
+package com.depromeet.member.domain;
+
+import com.depromeet.converter.AbstractCodedEnumConverter;
+import com.depromeet.converter.CodedEnum;
+
+public enum MemberGender implements CodedEnum<String> {
+    M("M"),
+    W("W");
+
+    private final String value;
+
+    MemberGender(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @jakarta.persistence.Converter(autoApply = true)
+    static class Converter extends AbstractCodedEnumConverter<MemberGender, String> {
+        public Converter() {
+            super(MemberGender.class);
+        }
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUpdateUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUpdateUseCase.java
@@ -3,7 +3,7 @@ package com.depromeet.member.port.in.usecase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 
-public interface UpdateUseCase {
+public interface MemberUpdateUseCase {
     Member updateName(Long memberId, String name);
 
     Member updateGender(Long memberId, MemberGender gender);

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/UpdateUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/UpdateUseCase.java
@@ -1,7 +1,10 @@
 package com.depromeet.member.port.in.usecase;
 
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
 
-public interface NameUpdateUseCase {
+public interface UpdateUseCase {
     Member updateName(Long memberId, String name);
+
+    Member updateGender(Long memberId, MemberGender gender);
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
@@ -1,6 +1,7 @@
 package com.depromeet.member.port.out.persistence;
 
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
 import java.util.Optional;
 
 public interface MemberPersistencePort {
@@ -15,4 +16,6 @@ public interface MemberPersistencePort {
     Optional<Member> updateName(Long memberId, String name);
 
     Optional<Member> findByProviderId(String providerId);
+
+    Optional<Member> updateGender(Long memberId, MemberGender gender);
 }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -9,8 +9,8 @@ import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.MemberRole;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 import com.depromeet.member.port.in.usecase.GoalUpdateUseCase;
+import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
-import com.depromeet.member.port.in.usecase.UpdateUseCase;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.depromeet.type.member.MemberErrorType;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class MemberService implements MemberUseCase, GoalUpdateUseCase, UpdateUseCase {
+public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUpdateUseCase {
     private final MemberPersistencePort memberPersistencePort;
     private final RefreshRedisPersistencePort refreshRedisPersistencePort;
 
@@ -76,7 +76,7 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, UpdateUs
     @Override
     public Member updateGender(Long memberId, MemberGender gender) {
         if (gender == null) {
-            throw new BadRequestException(MemberErrorType.NAME_CANNOT_BE_BLANK);
+            throw new BadRequestException(MemberErrorType.GENDER_CANNOT_BE_BLANK);
         }
         return memberPersistencePort
                 .updateGender(memberId, gender)

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -4,11 +4,12 @@ import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.MemberRole;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 import com.depromeet.member.port.in.usecase.GoalUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
-import com.depromeet.member.port.in.usecase.NameUpdateUseCase;
+import com.depromeet.member.port.in.usecase.UpdateUseCase;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.depromeet.type.member.MemberErrorType;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class MemberService implements MemberUseCase, GoalUpdateUseCase, NameUpdateUseCase {
+public class MemberService implements MemberUseCase, GoalUpdateUseCase, UpdateUseCase {
     private final MemberPersistencePort memberPersistencePort;
 
     @Override
@@ -61,5 +62,16 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, NameUpda
         return memberPersistencePort
                 .updateName(memberId, name)
                 .orElseThrow(() -> new InternalServerException(MemberErrorType.UPDATE_NAME_FAILED));
+    }
+
+    @Override
+    public Member updateGender(Long memberId, MemberGender gender) {
+        if (gender == null) {
+            throw new BadRequestException(MemberErrorType.NAME_CANNOT_BE_BLANK);
+        }
+        return memberPersistencePort
+                .updateGender(memberId, gender)
+                .orElseThrow(
+                        () -> new InternalServerException(MemberErrorType.UPDATE_GENDER_FAILED));
     }
 }

--- a/module-independent/src/main/java/com/depromeet/annotation/Enum.java
+++ b/module-independent/src/main/java/com/depromeet/annotation/Enum.java
@@ -1,0 +1,24 @@
+package com.depromeet.annotation;
+
+import com.depromeet.validator.EnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum {
+    String message() default "Invalid value. This is not permitted.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends java.lang.Enum<?>> enumClass();
+
+    boolean ignoreCase() default false;
+}

--- a/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
@@ -7,7 +7,8 @@ public enum MemberErrorType implements ErrorType {
     UPDATE_GOAL_FAILED("MEMBER_2", "멤버의 목표 수정에 실패하였습니다"),
     UPDATE_NAME_FAILED("MEMBER_3", "멤버의 이름 수정에 실패하였습니다"),
     NAME_CANNOT_BE_BLANK("MEMBER_4", "멤버의 이름은 공백이 허용되지 않습니다"),
-    UPDATE_GENDER_FAILED("MEMBER_5", "멤버의 성별 수정에 실패하였습니다");
+    UPDATE_GENDER_FAILED("MEMBER_5", "멤버의 성별 수정에 실패하였습니다"),
+    GENDER_CANNOT_BE_BLANK("MEMBER_6", "멤버의 성별은 공백이 허용되지 않습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
@@ -6,7 +6,8 @@ public enum MemberErrorType implements ErrorType {
     NOT_FOUND("MEMBER_1", "멤버가 존재하지 않습니다"),
     UPDATE_GOAL_FAILED("MEMBER_2", "멤버의 목표 수정에 실패하였습니다"),
     UPDATE_NAME_FAILED("MEMBER_3", "멤버의 이름 수정에 실패하였습니다"),
-    NAME_CANNOT_BE_BLANK("MEMBER_4", "멤버의 이름은 공백이 허용되지 않습니다");
+    NAME_CANNOT_BE_BLANK("MEMBER_4", "멤버의 이름은 공백이 허용되지 않습니다"),
+    UPDATE_GENDER_FAILED("MEMBER_5", "멤버의 성별 수정에 실패하였습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/member/MemberSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/member/MemberSuccessType.java
@@ -6,7 +6,8 @@ public enum MemberSuccessType implements SuccessType {
     GET_SUCCESS("MEMBER_1", "멤버 조회에 성공하였습니다"),
     UPDATE_GOAL_SUCCESS("MEMBER_2", "멤버 목표 수정에 성공하였습니다"),
     GET_GOAL_SUCCESS("MEMBER_3", "멤버 목표 조회에 성공하였습니다"),
-    UPDATE_NAME_SUCCESS("MEMBER_4", "멤버 이름 수정에 성공하였습니다");
+    UPDATE_NAME_SUCCESS("MEMBER_4", "멤버 이름 수정에 성공하였습니다"),
+    UPDATE_GENDER_SUCCESS("MEMBER_5", "멤버 성별 수정에 성공하였습니다");
 
     private final String code;
 

--- a/module-independent/src/main/java/com/depromeet/validator/EnumValidator.java
+++ b/module-independent/src/main/java/com/depromeet/validator/EnumValidator.java
@@ -1,0 +1,31 @@
+package com.depromeet.validator;
+
+import com.depromeet.annotation.Enum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<Enum, String> {
+    private Enum annotation;
+
+    @Override
+    public void initialize(Enum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        boolean result = false;
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString())
+                        || (this.annotation.ignoreCase()
+                                && value.equalsIgnoreCase(enumValue.toString()))) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -1,6 +1,7 @@
 package com.depromeet.member.entity;
 
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.MemberRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,22 +32,33 @@ public class MemberEntity {
 
     @Column private String providerId;
 
-    private Integer goal;
+    @Column private Integer goal;
+
+    @Column(columnDefinition = "char", nullable = false)
+    private MemberGender gender;
 
     @Builder
     public MemberEntity(
-            Long id, String name, String email, MemberRole role, String providerId, Integer goal) {
+            Long id,
+            String name,
+            String email,
+            MemberRole role,
+            String providerId,
+            Integer goal,
+            MemberGender gender) {
         this.id = id;
         this.name = name;
         this.email = email;
         this.role = role;
         this.providerId = providerId;
         this.goal = goal;
+        this.gender = gender;
     }
 
     @PrePersist
     public void prePersist() {
         this.goal = 1000;
+        this.gender = MemberGender.M;
     }
 
     public static MemberEntity from(Member member) {
@@ -57,6 +69,7 @@ public class MemberEntity {
                 .role(member.getRole())
                 .providerId(member.getProviderId())
                 .goal(member.getGoal())
+                .gender(member.getGender())
                 .build();
     }
 
@@ -68,6 +81,7 @@ public class MemberEntity {
                 .role(role)
                 .providerId(providerId)
                 .goal(goal)
+                .gender(gender)
                 .build();
     }
 
@@ -78,6 +92,11 @@ public class MemberEntity {
 
     public MemberEntity updateName(String name) {
         this.name = name;
+        return this;
+    }
+
+    public MemberEntity updateGender(MemberGender gender) {
+        this.gender = gender;
         return this;
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.depromeet.member.repository;
 
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.entity.MemberEntity;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import java.util.Optional;
@@ -44,5 +45,12 @@ public class MemberRepository implements MemberPersistencePort {
     @Override
     public Optional<Member> findByProviderId(String providerId) {
         return memberJpaRepository.findByProviderId(providerId).map(MemberEntity::toModel);
+    }
+
+    @Override
+    public Optional<Member> updateGender(Long memberId, MemberGender gender) {
+        return memberJpaRepository
+                .findById(memberId)
+                .map(memberEntity -> memberEntity.updateGender(gender).toModel());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
@@ -3,14 +3,15 @@ package com.depromeet.auth.dto.response;
 import com.depromeet.auth.vo.JwtToken;
 import java.util.Objects;
 
-public record JwtTokenResponse(Long userId, String accessToken, String refreshToken) {
+public record JwtTokenResponse(Long userId, String name, String accessToken, String refreshToken) {
     public JwtTokenResponse {
         Objects.requireNonNull(userId);
         Objects.requireNonNull(accessToken);
         Objects.requireNonNull(refreshToken);
     }
 
-    public static JwtTokenResponse of(JwtToken token) {
-        return new JwtTokenResponse(token.userId(), token.accessToken(), token.refreshToken());
+    public static JwtTokenResponse of(JwtToken token, String name) {
+        return new JwtTokenResponse(
+                token.userId(), name, token.accessToken(), token.refreshToken());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -38,7 +38,7 @@ public class AuthFacade {
                         MemberMapper.toCommand(profile, "google " + profile.id()));
         JwtToken token = createTokenUseCase.generateToken(member.getId(), member.getRole());
 
-        return JwtTokenResponse.of(token);
+        return JwtTokenResponse.of(token, member.getName());
     }
 
     public JwtTokenResponse loginByKakao(KakaoLoginRequest request, String origin) {
@@ -57,7 +57,7 @@ public class AuthFacade {
                         MemberMapper.toCommand(account, "kakao " + profile.id()));
         JwtToken token = createTokenUseCase.generateToken(member.getId(), member.getRole());
 
-        return JwtTokenResponse.of(token);
+        return JwtTokenResponse.of(token, member.getName());
     }
 
     @Transactional(readOnly = true)

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberApi.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberApi.java
@@ -2,8 +2,10 @@ package com.depromeet.member.api;
 
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
+import com.depromeet.member.dto.request.GenderUpdateRequest;
 import com.depromeet.member.dto.request.NameUpdateRequest;
 import com.depromeet.member.dto.response.MemberFindOneResponse;
+import com.depromeet.member.dto.response.MemberGenderResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -18,4 +20,9 @@ public interface MemberApi {
     @Operation(summary = "닉네임 수정")
     ApiResponse<MemberFindOneResponse> updateName(
             @LoginMember Long memberId, @Valid @RequestBody NameUpdateRequest updateNameRequest);
+
+    @Operation(summary = "성별 수정")
+    ApiResponse<MemberGenderResponse> updateGender(
+            @LoginMember Long memberId,
+            @Valid @RequestBody GenderUpdateRequest genderUpdateRequest);
 }

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -4,8 +4,10 @@ import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.dto.request.GenderUpdateRequest;
 import com.depromeet.member.dto.request.NameUpdateRequest;
 import com.depromeet.member.dto.response.MemberFindOneResponse;
+import com.depromeet.member.dto.response.MemberGenderResponse;
 import com.depromeet.member.facade.MemberFacade;
 import com.depromeet.type.member.MemberSuccessType;
 import jakarta.validation.Valid;
@@ -32,5 +34,15 @@ public class MemberController implements MemberApi {
         Member member = memberFacade.updateName(memberId, updateNameRequest.name());
         return ApiResponse.success(
                 MemberSuccessType.UPDATE_NAME_SUCCESS, MemberFindOneResponse.of(member));
+    }
+
+    @PatchMapping("/gender")
+    @Logging(item = "Member", action = "PATCH")
+    public ApiResponse<MemberGenderResponse> updateGender(
+            @LoginMember Long memberId,
+            @Valid @RequestBody GenderUpdateRequest genderUpdateRequest) {
+        Member member = memberFacade.updateGender(memberId, genderUpdateRequest.gender());
+        return ApiResponse.success(
+                MemberSuccessType.UPDATE_GENDER_SUCCESS, MemberGenderResponse.of(member));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/request/GenderUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/request/GenderUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.depromeet.member.dto.request;
+
+import com.depromeet.annotation.Enum;
+import com.depromeet.member.domain.MemberGender;
+import jakarta.validation.constraints.NotBlank;
+
+public record GenderUpdateRequest(
+        @NotBlank @Enum(enumClass = MemberGender.class, ignoreCase = true) String gender) {}

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberGenderResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberGenderResponse.java
@@ -1,0 +1,18 @@
+package com.depromeet.member.dto.response;
+
+import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemberGenderResponse(
+        Long id, Integer goal, String name, String email, MemberGender gender) {
+    public static MemberGenderResponse of(Member member) {
+        return new MemberGenderResponse(
+                member.getId(),
+                member.getGoal(),
+                member.getName(),
+                member.getEmail(),
+                member.getGender());
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -3,8 +3,8 @@ package com.depromeet.member.facade;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
+import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
-import com.depromeet.member.port.in.usecase.UpdateUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberFacade {
     private final MemberUseCase memberUseCase;
-    private final UpdateUseCase updateUseCase;
+    private final MemberUpdateUseCase memberUpdateUseCase;
 
     public Member findById(Long memberId) {
         return memberUseCase.findById(memberId);
@@ -25,12 +25,12 @@ public class MemberFacade {
     }
 
     public Member updateName(Long memberId, String name) {
-        return updateUseCase.updateName(memberId, name);
+        return memberUpdateUseCase.updateName(memberId, name);
     }
 
     public Member updateGender(Long memberId, String gender) {
         MemberGender newGender =
                 gender.equals(MemberGender.M.getValue()) ? MemberGender.M : MemberGender.W;
-        return updateUseCase.updateGender(memberId, newGender);
+        return memberUpdateUseCase.updateGender(memberId, newGender);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -1,9 +1,10 @@
 package com.depromeet.member.facade;
 
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
-import com.depromeet.member.port.in.usecase.NameUpdateUseCase;
+import com.depromeet.member.port.in.usecase.UpdateUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberFacade {
     private final MemberUseCase memberUseCase;
-    private final NameUpdateUseCase nameUpdateUseCase;
+    private final UpdateUseCase updateUseCase;
 
     public Member findById(Long memberId) {
         return memberUseCase.findById(memberId);
@@ -24,6 +25,12 @@ public class MemberFacade {
     }
 
     public Member updateName(Long memberId, String name) {
-        return nameUpdateUseCase.updateName(memberId, name);
+        return updateUseCase.updateName(memberId, name);
+    }
+
+    public Member updateGender(Long memberId, String gender) {
+        MemberGender newGender =
+                gender.equals(MemberGender.M.getValue()) ? MemberGender.M : MemberGender.W;
+        return updateUseCase.updateGender(memberId, newGender);
     }
 }

--- a/module-presentation/src/test/java/com/depromeet/member/controller/MemberControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/member/controller/MemberControllerTest.java
@@ -37,7 +37,14 @@ public class MemberControllerTest extends ControllerTestConfig {
         requestBody.put("name", "테스트");
 
         Member member =
-                new Member(1L, "테스트", "test@gmail.com", MemberRole.USER, "google 1234", 3000, MemberGender.M);
+                new Member(
+                        1L,
+                        "테스트",
+                        "test@gmail.com",
+                        MemberRole.USER,
+                        "google 1234",
+                        3000,
+                        MemberGender.M);
         when(memberFacade.updateName(anyLong(), anyString())).thenReturn(member);
 
         mockMvc.perform(


### PR DESCRIPTION
## 🌱 관련 이슈

- close #185

## 📌 작업 내용 및 특이사항
- 로그인 성공 시 DB에 저장된 이름을 반환합니다.
- 성별 수정을 할 수 있습니다.
- 성별의 기본 값은 M(남자)입니다.
- 회원가입 시 이름(닉네임)과 성별을 설정할 수 있습니다.
- 성별 수정 request에서 enum 타입 검증을 진행합니다.

## 📝 참고사항
- 회원 로그인 성공 시 응답
<img width="407" alt="Screenshot 2024-08-07 at 23 36 30" src="https://github.com/user-attachments/assets/e74add96-cd52-4bda-ab3e-02c8ed5db5a8">

- 회원 성별 수정 성공 시 응답
<img width="852" alt="Screenshot 2024-08-08 at 00 02 06" src="https://github.com/user-attachments/assets/599ebc5e-d1a8-4193-88e0-c2969cd5670d">

- 회원 성별 수정 실패(Enum 타입 다름) 시 응답
<img width="839" alt="Screenshot 2024-08-08 at 00 08 59" src="https://github.com/user-attachments/assets/d9fe6c7e-d7b6-47ce-b081-817a09a9bbb9">