### PR TITLE
Feature/196 get api for memory update

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -7,6 +7,7 @@ import com.depromeet.memory.dto.request.MemoryUpdateRequest;
 import com.depromeet.memory.dto.response.CalendarResponse;
 import com.depromeet.memory.dto.response.MemoryCreateResponse;
 import com.depromeet.memory.dto.response.MemoryResponse;
+import com.depromeet.memory.dto.response.MemoryUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +24,10 @@ public interface MemoryApi {
     ApiResponse<MemoryCreateResponse> create(
             @LoginMember Long memberId,
             @Valid @RequestBody MemoryCreateRequest memoryCreateRequest);
+
+    @Operation(summary = "수영 기록 수정을 위한 단일 조회")
+    ApiResponse<MemoryUpdateResponse> readForUpdate(
+            @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "수영 기록 단일 조회")
     ApiResponse<MemoryResponse> read(

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -5,10 +5,7 @@ import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
-import com.depromeet.memory.dto.response.CalendarResponse;
-import com.depromeet.memory.dto.response.MemoryCreateResponse;
-import com.depromeet.memory.dto.response.MemoryResponse;
-import com.depromeet.memory.dto.response.TimelineSliceResponse;
+import com.depromeet.memory.dto.response.*;
 import com.depromeet.memory.facade.MemoryFacade;
 import com.depromeet.type.memory.MemorySuccessType;
 import jakarta.validation.Valid;
@@ -37,6 +34,14 @@ public class MemoryController implements MemoryApi {
     public ApiResponse<MemoryResponse> read(
             @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId) {
         MemoryResponse response = memoryFacade.findById(memberId, memoryId);
+        return ApiResponse.success(MemorySuccessType.GET_RESULT_SUCCESS, response);
+    }
+
+    @GetMapping("/{memoryId}/edit-data")
+    @Logging(item = "Memory", action = "GET")
+    public ApiResponse<MemoryUpdateResponse> readForUpdate(
+            @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId) {
+        MemoryUpdateResponse response = memoryFacade.getMemoryForUpdate(memberId, memoryId);
         return ApiResponse.success(MemorySuccessType.GET_RESULT_SUCCESS, response);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -1,7 +1,6 @@
 package com.depromeet.memory.dto.response;
 
 import com.depromeet.member.domain.Member;
-import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.Memory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
@@ -13,7 +12,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CalendarResponse {
-    private MemberSimpleResponse member;
+    private Integer goal;
     private List<CalendarDetailResponse> memories;
 
     public static CalendarResponse of(Member member, List<Memory> memoryDomains) {
@@ -28,8 +27,7 @@ public class CalendarResponse {
                     CalendarDetailResponse.of(
                             memoryDomain, type, totalDistance, strokes, isAchieved));
         }
-        return new CalendarResponse(
-                MemberSimpleResponse.of(member.getGoal(), member.getNickname()), memories);
+        return new CalendarResponse(member.getGoal(), memories);
     }
 
     public static List<StrokeResponse> getStrokeResponses(Memory memoryDomain) {

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryUpdateResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryUpdateResponse.java
@@ -1,0 +1,216 @@
+package com.depromeet.memory.dto.response;
+
+import com.depromeet.image.domain.Image;
+import com.depromeet.image.dto.response.ImageSimpleResponse;
+import com.depromeet.member.dto.response.MemberSimpleResponse;
+import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.MemoryDetail;
+import com.depromeet.memory.domain.Stroke;
+import com.depromeet.pool.domain.Pool;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MemoryUpdateResponse {
+    @Schema(
+            description = "memory PK",
+            example = "1",
+            type = "long",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private Long id;
+
+    private MemberSimpleResponse member;
+    private Pool pool;
+    private MemoryDetailResponse memoryDetail;
+
+    @Schema(
+            description = "영법 타입(NORMAL, SINGLE, MULTI)",
+            example = "NORMAL",
+            type = "string",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String type;
+
+    private List<StrokeResponse> strokes;
+    private List<ImageSimpleResponse> images;
+
+    @Schema(
+            description = "작성일자",
+            example = "2024-08-01",
+            maxLength = 10,
+            type = "string",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private LocalDate recordAt;
+
+    @Schema(
+            description = "시작시간",
+            example = "11:00",
+            maxLength = 8,
+            type = "string",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime startTime;
+
+    @Schema(
+            description = "종료시간",
+            example = "11:50",
+            maxLength = 8,
+            type = "string",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime endTime;
+
+    @Schema(description = "운동시간", example = "00:50", maxLength = 8, type = "string")
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime duration;
+
+    @Schema(
+            description = "레인 길이",
+            example = "25",
+            maxLength = 3,
+            type = "int",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Short lane;
+
+    @Schema(
+            description = "총 바퀴",
+            example = "3",
+            maxLength = 3,
+            type = "int",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Float totalLap;
+
+    @Schema(
+            description = "총 미터",
+            example = "500",
+            maxLength = 8,
+            type = "int",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Integer totalMeter;
+
+    @Schema(
+            description = "일기",
+            example = "수영 기록",
+            type = "string",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String diary;
+
+    @Builder
+    public MemoryUpdateResponse(
+            Long id,
+            MemberSimpleResponse member,
+            Pool pool,
+            MemoryDetail memoryDetail,
+            String type,
+            List<Stroke> strokes,
+            List<Image> images,
+            LocalDate recordAt,
+            LocalTime startTime,
+            LocalTime endTime,
+            Short lane,
+            String diary) {
+        List<StrokeResponse> resultStrokes = getResultStrokes(strokes, lane);
+
+        Float totalLap = 0F;
+        Integer totalMeter = 0;
+        for (StrokeResponse stroke : resultStrokes) {
+            totalLap = calculateTotalLaps(lane, stroke, totalLap);
+            totalMeter = calculateTotalMeter(lane, stroke, totalMeter);
+        }
+
+        this.id = id;
+        this.member = member;
+        this.pool = pool;
+        this.memoryDetail = getMemoryDetail(memoryDetail);
+        this.type = type;
+        this.strokes = resultStrokes;
+        this.images = getImageSource(images);
+        this.recordAt = recordAt;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.duration = getDuration(startTime, endTime);
+        this.lane = lane;
+        this.totalLap = totalLap;
+        this.totalMeter = totalMeter;
+        this.diary = diary;
+    }
+
+    private static Integer calculateTotalMeter(
+            Short lane, StrokeResponse stroke, Integer totalMeter) {
+        if (stroke.meter() != null && stroke.meter() != 0) {
+            totalMeter += stroke.meter();
+        } else {
+            if (stroke.laps() != null) {
+                totalMeter += (short) (stroke.laps() * 2) * lane;
+            }
+        }
+        return totalMeter;
+    }
+
+    private Float calculateTotalLaps(Short lane, StrokeResponse stroke, Float totalLap) {
+        if (stroke.laps() != null && stroke.laps() != 0) {
+            totalLap += stroke.laps();
+        } else {
+            totalLap += ((float) stroke.meter()) / (lane * 2);
+        }
+        return totalLap;
+    }
+
+    private static MemoryDetailResponse getMemoryDetail(MemoryDetail memoryDetail) {
+        if (memoryDetail == null) return null;
+        return MemoryDetailResponse.of(memoryDetail);
+    }
+
+    private static LocalTime getDuration(LocalTime startTime, LocalTime endTime) {
+        return LocalTime.of(
+                endTime.minusHours(startTime.getHour()).getHour(),
+                endTime.minusMinutes(startTime.getMinute()).getMinute(),
+                0);
+    }
+
+    private static List<ImageSimpleResponse> getImageSource(List<Image> images) {
+        return images.stream().map(ImageSimpleResponse::of).toList();
+    }
+
+    private static List<StrokeResponse> getResultStrokes(List<Stroke> strokes, Short lane) {
+        return strokes.stream()
+                .map(
+                        stroke ->
+                                StrokeResponse.builder()
+                                        .strokeId(stroke.getId())
+                                        .name(stroke.getName())
+                                        .laps(stroke.getLaps())
+                                        .meter(stroke.getMeter())
+                                        .build())
+                .toList();
+    }
+
+    public static MemoryUpdateResponse from(Memory memory) {
+        Integer goal = memory.getMember().getGoal();
+        String nickname = memory.getMember().getNickname();
+
+        MemberSimpleResponse memberSimple = MemberSimpleResponse.of(goal, nickname);
+        return MemoryUpdateResponse.builder()
+                .id(memory.getId())
+                .member(memberSimple)
+                .pool(memory.getPool())
+                .memoryDetail(memory.getMemoryDetail())
+                .type(memory.classifyType())
+                .strokes(memory.getStrokes())
+                .images(memory.getImages())
+                .recordAt(memory.getRecordAt())
+                .startTime(memory.getStartTime())
+                .endTime(memory.getEndTime())
+                .lane(memory.getLane())
+                .diary(memory.getDiary())
+                .build();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
@@ -1,6 +1,5 @@
 package com.depromeet.memory.dto.response;
 
-import com.depromeet.member.dto.response.MemberSimpleResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
@@ -9,10 +8,10 @@ public record TimelineSliceResponse(
         @Schema(description = "타임라인 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
                 List<TimelineResponse> content,
         @Schema(
-                        description = "멤버 목표",
+                        description = "사용자 목표",
                         example = "1000",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-                MemberSimpleResponse member,
+                Integer goal,
         @Schema(description = "페이지 크기", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
                 int pageSize,
         @Schema(

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -10,10 +10,7 @@ import com.depromeet.memory.domain.Stroke;
 import com.depromeet.memory.domain.vo.Timeline;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
-import com.depromeet.memory.dto.response.CalendarResponse;
-import com.depromeet.memory.dto.response.MemoryCreateResponse;
-import com.depromeet.memory.dto.response.MemoryResponse;
-import com.depromeet.memory.dto.response.TimelineSliceResponse;
+import com.depromeet.memory.dto.response.*;
 import com.depromeet.memory.mapper.MemoryMapper;
 import com.depromeet.memory.port.in.command.CreateStrokeCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
@@ -79,6 +76,12 @@ public class MemoryFacade {
         UpdateMemoryCommand command = MemoryMapper.toCommand(request);
 
         return MemoryResponse.from(updateMemoryUseCase.update(memoryId, command, strokes));
+    }
+
+    public MemoryUpdateResponse getMemoryForUpdate(Long memberId, Long memoryId) {
+        Memory memory = getMemoryUseCase.findById(memoryId);
+        validatePermission(memory.getMember().getId(), memberId);
+        return MemoryUpdateResponse.from(memory);
     }
 
     public MemoryResponse findById(Long memberId, Long memoryId) {

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -1,7 +1,6 @@
 package com.depromeet.memory.mapper;
 
 import com.depromeet.member.domain.Member;
-import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.vo.Timeline;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
@@ -81,7 +80,7 @@ public class MemoryMapper {
 
         return TimelineSliceResponse.builder()
                 .content(result)
-                .member(MemberSimpleResponse.from(member.getGoal()))
+                .goal(member.getGoal())
                 .pageSize(timeline.getPageSize())
                 .cursorRecordAt(getCursorRecordAtResponse(timeline))
                 .hasNext(timeline.isHasNext())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #

## 📌 작업 내용 및 특이사항
- 기존 단건 조회 시 meter, laps 가 조회되어 나왔으나 수정시 사용할 조회용 API를 추가
-  타임라인, 캘린더 조회 시 member 래핑 제거 후, goal만 리턴

기록 수정용 조회 API 에서 totalLaps와 totalMeter는 그대로 계산

## 📝 참고사항
기록 수정 전용 api
![image](https://github.com/user-attachments/assets/feda3872-5a11-4c2a-a083-de3c13fd978b)

타임라인 api
![image](https://github.com/user-attachments/assets/364e33d3-9cad-4008-8e2a-f77f8dd2496c)

캘린더 api
![image](https://github.com/user-attachments/assets/dc9b2cd0-ee9c-4355-beb7-70000dc78712)