### PR TITLE
feat: 애플 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/application-secret.properties
+**/Swimie_AuthKey_B52ZG9MWCW.p8
 **/data.sql
 generated
 

--- a/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
@@ -8,5 +8,7 @@ public interface SocialUseCase {
 
     KakaoAccountProfile getKakaoAccountProfile(String code, String origin);
 
+    AccountProfileResponse getAppleAccountToken(String code, String origin);
+
     void revokeAccount(String accountType);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/ApplePort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/ApplePort.java
@@ -1,0 +1,7 @@
+package com.depromeet.auth.port.out;
+
+import com.depromeet.dto.auth.AccountProfileResponse;
+
+public interface ApplePort {
+    AccountProfileResponse getAppleAccountToken(String code, String origin);
+}

--- a/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
+++ b/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
@@ -1,6 +1,7 @@
 package com.depromeet.auth.service;
 
 import com.depromeet.auth.port.in.usecase.SocialUseCase;
+import com.depromeet.auth.port.out.ApplePort;
 import com.depromeet.auth.port.out.GooglePort;
 import com.depromeet.auth.port.out.KakaoPort;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class SocialService implements SocialUseCase {
     private final KakaoPort kakaoPort;
     private final GooglePort googlePort;
+    private final ApplePort applePort;
 
     @Override
     public AccountProfileResponse getGoogleAccountProfile(String code, String origin) {
@@ -26,6 +28,11 @@ public class SocialService implements SocialUseCase {
     @Override
     public KakaoAccountProfile getKakaoAccountProfile(String code, String origin) {
         return kakaoPort.getKakaoAccountProfile(code, origin);
+    }
+
+    @Override
+    public AccountProfileResponse getAppleAccountToken(String code, String origin) {
+        return applePort.getAppleAccountToken(code, origin);
     }
 
     @Override

--- a/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
@@ -20,7 +20,11 @@ public enum AuthErrorType implements ErrorType {
     OAUTH_ACCESS_TOKEN_NOT_FOUND("AUTH_16", "OAUTH ACCESS 토큰을 찾을 수 없습니다"),
     INVALID_OAUTH_ACCESS_TOKEN("AUTH_17", "OAUTH ACCESS 토큰이 올바르지 않습니다"),
     OAUTH_REFRESH_TOKEN_NOT_FOUND("AUTH_18", "OAUTH REFRESH 토큰을 찾을 수 없습니다"),
-    REVOKE_GOOGLE_ACCOUNT_FAILED("AUTH_19", "GOOGLE 계정 연결 끊기에 실패하였습니다");
+    REVOKE_GOOGLE_ACCOUNT_FAILED("AUTH_19", "GOOGLE 계정 연결 끊기에 실패하였습니다"),
+    INVALID_APPLE_KEY_REQUEST("AUTH_20", "APPLE 공개키 요청에 실패하였습니다"),
+    GENERATE_APPLE_PUBLIC_KEY_FAILED("AUTH_21", "APPLE 공개키 생성에 실패하였습니다"),
+    CANNOT_FIND_MATCH_JWK("AUTH_22", "일치하는 APPLE JWK 를 찾을 수 없습니다"),
+    JWT_PARSE_FAILED("AUTH_23", "JWT PARSING 에 실패하였습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/security/build.gradle
+++ b/module-infrastructure/security/build.gradle
@@ -17,4 +17,7 @@ dependencies {
     // google oauth2
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
     implementation 'com.google.api-client:google-api-client:1.32.1'
+
+    // apple private key parsing
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
 }

--- a/module-infrastructure/security/src/main/java/com/depromeet/SecurityConfig.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                                 .permitAll() // oauth2
                                 .requestMatchers("/swagger-ui/**", "/v3/**", "/favicon.ico")
                                 .permitAll() // swagger
-                                .requestMatchers("/login/kakao", "/login/google")
+                                .requestMatchers("/login/kakao", "/login/google", "/login/apple")
                                 .permitAll() // 로그인 및 회원가입
                                 .anyRequest()
                                 .authenticated());

--- a/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/AppleJwk.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/AppleJwk.java
@@ -1,0 +1,3 @@
+package com.depromeet.oauth.dto.response;
+
+public record AppleJwk(String alg, String e, String kid, String kty, String n, String use) {}

--- a/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/AppleJwkSet.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/AppleJwkSet.java
@@ -1,0 +1,5 @@
+package com.depromeet.oauth.dto.response;
+
+import java.util.List;
+
+public record AppleJwkSet(List<AppleJwk> keys) {}

--- a/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/AppleTokenResponse.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/oauth/dto/response/AppleTokenResponse.java
@@ -1,0 +1,12 @@
+package com.depromeet.oauth.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AppleTokenResponse(
+        String accessToken,
+        String tokenType,
+        Integer expiresIn,
+        String refreshToken,
+        String idToken) {}

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
@@ -132,7 +132,7 @@ public class AppleClient implements ApplePort {
     private String createClientSecret() {
         LocalDateTime now = LocalDateTime.now();
         Date expirationDate =
-                Date.from(now.plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+                Date.from(now.plusHours(2).atZone(ZoneId.systemDefault()).toInstant());
 
         try {
             return Jwts.builder()

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
@@ -1,0 +1,218 @@
+package com.depromeet.util;
+
+import com.depromeet.auth.port.out.ApplePort;
+import com.depromeet.auth.port.out.persistence.SocialRedisPersistencePort;
+import com.depromeet.dto.auth.AccountProfileResponse;
+import com.depromeet.exception.BadRequestException;
+import com.depromeet.exception.InternalServerException;
+import com.depromeet.exception.NotFoundException;
+import com.depromeet.exception.UnauthorizedException;
+import com.depromeet.oauth.dto.response.AppleJwk;
+import com.depromeet.oauth.dto.response.AppleJwkSet;
+import com.depromeet.oauth.dto.response.AppleTokenResponse;
+import com.depromeet.type.auth.AuthErrorType;
+import com.depromeet.type.common.CommonErrorType;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import io.jsonwebtoken.*;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleClient implements ApplePort {
+    @Value("${apple.client-id}")
+    private String clientId;
+
+    @Value("${apple.client-redirect-uri}")
+    private String redirectUri;
+
+    @Value("${apple.sign-key-id}")
+    private String appleSignKeyId;
+
+    @Value("${apple.team-id}")
+    private String appleTeamId;
+
+    @Value("${apple.bundle-id}")
+    private String appleBundleId;
+
+    @Value("${apple.sign-key-file-path}")
+    private String appleSignKeyFilePath;
+
+    @Value("${jwt.access-token-expiration-time}")
+    private Long ATExpireTime;
+
+    @Value("${jwt.refresh-token-expiration-time}")
+    private Long RTExpireTime;
+
+    private final RestTemplate restTemplate;
+    private final SocialRedisPersistencePort socialRedisPersistencePort;
+
+    @Override
+    public AccountProfileResponse getAppleAccountToken(String code, String origin) {
+        final AppleTokenResponse appleTokenResponse = requestTokens(code, origin);
+        if (appleTokenResponse == null) {
+            throw new BadRequestException(AuthErrorType.LOGIN_FAILED);
+        }
+        String idToken = appleTokenResponse.idToken();
+
+        AppleJwkSet jwkSets =
+                restTemplate.getForObject(
+                        "https://appleid.apple.com/auth/oauth2/v2/keys", AppleJwkSet.class);
+        if (jwkSets == null) {
+            throw new BadRequestException(AuthErrorType.INVALID_APPLE_KEY_REQUEST);
+        }
+
+        AppleJwk jwk = getMatchedJwk(idToken, jwkSets);
+        PublicKey publicKey = generatePublicKey(jwk.kty(), jwk.n(), jwk.e());
+
+        Claims payload = parseIdToken(publicKey, idToken);
+        socialRedisPersistencePort.setATData(
+                payload.getSubject(), appleTokenResponse.accessToken(), ATExpireTime);
+        socialRedisPersistencePort.setRTData(
+                payload.getSubject(), appleTokenResponse.refreshToken(), RTExpireTime);
+        return new AccountProfileResponse(
+                payload.getSubject(), "김스위미", payload.get("email", String.class));
+    }
+
+    private AppleTokenResponse requestTokens(String code, String origin) {
+        final String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", createClientSecret());
+        body.add("code", decodedCode);
+        body.add("grant_type", "authorization_code");
+        body.add("redirect_uri", origin + redirectUri);
+        final HttpEntity<MultiValueMap<String, String>> httpEntity =
+                new HttpEntity<>(body, headers);
+        ResponseEntity<AppleTokenResponse> res =
+                restTemplate.postForEntity(
+                        "https://appleid.apple.com/auth/token",
+                        httpEntity,
+                        AppleTokenResponse.class);
+        if (res.getStatusCode().is4xxClientError()) {
+            throw new BadRequestException(AuthErrorType.LOGIN_FAILED);
+        }
+        return res.getBody();
+    }
+
+    private String createClientSecret() {
+        LocalDateTime now = LocalDateTime.now();
+        Date expirationDate =
+                Date.from(now.plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+
+        try {
+            return Jwts.builder()
+                    .header()
+                    .keyId(appleSignKeyId)
+                    .and()
+                    .issuer(appleTeamId)
+                    .issuedAt(
+                            Date.from(
+                                    now.atZone(ZoneId.systemDefault())
+                                            .toInstant())) // 발행 시간 - UNIX 시간
+                    .expiration(expirationDate) // 만료 시간
+                    .audience()
+                    .add("https://appleid.apple.com")
+                    .and()
+                    .subject(appleBundleId)
+                    .signWith(getPrivateKey())
+                    .compact();
+        } catch (IOException e) {
+            throw new InternalServerException(CommonErrorType.IO);
+        }
+    }
+
+    private PrivateKey getPrivateKey() throws IOException {
+        ClassPathResource resource = new ClassPathResource(appleSignKeyFilePath);
+        String privateKey = new String(Files.readAllBytes(Paths.get(resource.getURI())));
+
+        Reader pemReader = new StringReader(privateKey);
+        PEMParser pemParser = new PEMParser(pemReader);
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+        PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
+        return converter.getPrivateKey(object);
+    }
+
+    private AppleJwk getMatchedJwk(String idToken, AppleJwkSet jwkSets) {
+        try {
+            JWT parse = JWTParser.parse(idToken);
+            Map<String, Object> idTokenHeader = parse.getHeader().toJSONObject();
+
+            for (AppleJwk jwk : jwkSets.keys()) {
+                if (jwk.kid().equals(idTokenHeader.get("kid"))
+                        && jwk.alg().equals(idTokenHeader.get("alg"))) {
+                    return jwk;
+                }
+            }
+            throw new NotFoundException(AuthErrorType.CANNOT_FIND_MATCH_JWK);
+        } catch (ParseException e) {
+            throw new InternalServerException(AuthErrorType.JWT_PARSE_FAILED);
+        }
+    }
+
+    private PublicKey generatePublicKey(String kty, String n, String e) {
+        final byte[] nBytes = Base64.getUrlDecoder().decode(n);
+        final byte[] eBytes = Base64.getUrlDecoder().decode(e);
+
+        final BigInteger bn = new BigInteger(1, nBytes);
+        final BigInteger be = new BigInteger(1, eBytes);
+        final RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(bn, be);
+
+        try {
+            final KeyFactory keyFactory = KeyFactory.getInstance(kty);
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new UnauthorizedException(AuthErrorType.GENERATE_APPLE_PUBLIC_KEY_FAILED);
+        }
+    }
+
+    private Claims parseIdToken(PublicKey publicKey, String idToken) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(idToken)
+                    .getPayload();
+        } catch (MalformedJwtException e) {
+            throw new UnauthorizedException(AuthErrorType.INVALID_JWT_ACCESS_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new UnauthorizedException(AuthErrorType.JWT_ACCESS_TOKEN_NOT_FOUND);
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(AuthErrorType.JWT_ACCESS_TOKEN_EXPIRED);
+        }
+    }
+}

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/GoogleClient.java
@@ -54,6 +54,7 @@ public class GoogleClient implements GooglePort {
     private final RestTemplate restTemplate;
     private final SocialRedisPersistencePort socialRedisPersistencePort;
 
+    @Override
     public AccountProfileResponse getGoogleAccountProfile(final String code, String origin) {
         final GoogleTokenResponse googleTokenResponse = requestAccessToken(code, origin);
         String accessToken = googleTokenResponse.getAccessToken();

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthApi.java
@@ -1,5 +1,6 @@
 package com.depromeet.auth.api;
 
+import com.depromeet.auth.dto.request.AppleLoginRequest;
 import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
@@ -24,6 +25,9 @@ public interface AuthApi {
     ApiResponse<JwtTokenResponse> loginByKakao(
             @Valid @RequestBody final KakaoLoginRequest request,
             HttpServletRequest httpServletRequest);
+
+    @Operation(summary = "애플 소셜로그인")
+    ApiResponse<JwtTokenResponse> loginByApple(@Valid @RequestBody final AppleLoginRequest request);
 
     @Operation(summary = "Access 토큰 재발급 요청")
     ApiResponse<JwtAccessTokenResponse> reissueAccessToken(

--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -1,5 +1,6 @@
 package com.depromeet.auth.api;
 
+import com.depromeet.auth.dto.request.AppleLoginRequest;
 import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
@@ -37,6 +38,13 @@ public class AuthController implements AuthApi {
         String origin = getOrigin(httpServletRequest);
         return ApiResponse.success(
                 AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByKakao(request, origin));
+    }
+
+    @PostMapping("/login/apple")
+    @Logging(item = "Auth", action = "POST")
+    public ApiResponse<JwtTokenResponse> loginByApple(
+            @Valid @RequestBody final AppleLoginRequest request) {
+        return ApiResponse.success(AuthSuccessType.LOGIN_SUCCESS, authFacade.loginByApple(request));
     }
 
     @PostMapping("/login/refresh")

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleLoginRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleLoginRequest.java
@@ -1,0 +1,5 @@
+package com.depromeet.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AppleLoginRequest(@NotNull(message = "인가 코드는 null일 수 없습니다") String code) {}

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -63,8 +63,7 @@ public class AuthFacade {
 
     public JwtTokenResponse loginByApple(AppleLoginRequest request) {
         final AccountProfileResponse profile =
-                socialUseCase.getAppleAccountToken(
-                        request.code(), "https://swimie.life");
+                socialUseCase.getAppleAccountToken(request.code(), "https://swimie.life");
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -1,5 +1,6 @@
 package com.depromeet.auth.facade;
 
+import com.depromeet.auth.dto.request.AppleLoginRequest;
 import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
@@ -57,6 +58,20 @@ public class AuthFacade {
                         MemberMapper.toCommand(account, "kakao " + profile.id()));
         JwtToken token = createTokenUseCase.generateToken(member.getId(), member.getRole());
 
+        return JwtTokenResponse.of(token, member.getNickname());
+    }
+
+    public JwtTokenResponse loginByApple(AppleLoginRequest request) {
+        final AccountProfileResponse profile =
+                socialUseCase.getAppleAccountToken(
+                        request.code(), "https://swimie.life");
+        if (profile == null) {
+            throw new NotFoundException(AuthErrorType.NOT_FOUND);
+        }
+        final Member member =
+                memberUseCase.findOrCreateMemberBy(
+                        MemberMapper.toCommand(profile, "apple " + profile.id()));
+        JwtToken token = createTokenUseCase.generateToken(member.getId(), member.getRole());
         return JwtTokenResponse.of(token, member.getNickname());
     }
 

--- a/module-presentation/src/main/resources/application-db.yml
+++ b/module-presentation/src/main/resources/application-db.yml
@@ -7,6 +7,11 @@ spring:
     url: ${MYSQL_URL} # 환경변수에 값 추가하시면 됩니다.
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PW}
 
 logging:
   level:

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -15,11 +15,6 @@ spring:
   sql:
     init:
       mode: never
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ${REDIS_PW}
   servlet:
     multipart:
       enabled: true

--- a/module-presentation/src/main/resources/application-prod.yml
+++ b/module-presentation/src/main/resources/application-prod.yml
@@ -15,11 +15,6 @@ spring:
   sql:
     init:
       mode: never
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-      password: ${REDIS_PW}
   servlet:
     multipart:
       enabled: true

--- a/module-presentation/src/main/resources/application-security.yml
+++ b/module-presentation/src/main/resources/application-security.yml
@@ -36,6 +36,15 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+
+apple:
+  client-id: ${APPLE_CLIENT_ID}
+  client-redirect-uri: ${APPLE_CLIENT_REDIRECT_URL}
+  sign-key-id: ${APPLE_SIGN_KEY_ID}
+  team-id: ${APPLE_TEAM_ID}
+  bundle-id: ${APPLE_BUNDLE_ID}
+  sign-key-file-path: ${APPLE_SIGN_KEY_FILE_PATH}
+
 jwt:
   access-token-secret: ${ACCESS_TOKEN_SECRET}
   refresh-token-secret: ${REFRESH_TOKEN_SECRET}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #204

## 📌 작업 내용 및 특이사항
- 애플 로그인을 구현하였습니다.
- 클라이언트 측 작업 부담을 줄이기 위해, 간략한 방식의 애플 로그인을 채택하였습니다.
1. 애플 인증 서버로부터 code를 받습니다.
2. spring 서버로 code를 담아 보냅니다. (`/login/apple` POST)
3. code와 client secret을 활용하여 spring 서버에서 애플 인증 서버로부터 access token, refresh token, id token 정보를 받습니다.
4. 애플에서 제공하는 공개키를 통해 id token을 paring 합니다.
5. id token에 담겨 있는 인증 서버 내부 id 값과 email 정보를 가져옵니다.
6. 우리 데이터베이스 서버에 해당 내용을 저장하며, **닉네임은 "김스위미"로 임시 지정합니다.** (회원가입 플로우에서 수정 됩니다.)
7. 애플에서 제공받은 AT, RT는 redis에 저장합니다.
8. 응답 값으로 spring 서버에서 만들어낸 AT, RT JWT 토큰을 제공합니다.

## 📝 참고사항
- Swimie_AuthKey_ABCD.p8 파일을 presentation 모듈의 `src/main/resources` 경로에 저장해 주세요.
- 해당 파일은 슬랙 캔버스에서 확인할 수 있습니다.
- 슬랙 캔버스의 apple 관련 환경 변수를 추가해 주세요.
- 파일 및 환경변수는 배포 서버에 반영해 두도록 하겠습니다.
- 로컬에서 테스트가 불가능합니다. 테스트를 원하시는 경우, 클라이언트 코드에서 ngrok를 사용하셔야 합니다.
---
- 성공 응답
<img width="846" alt="Screenshot 2024-08-13 at 17 31 14" src="https://github.com/user-attachments/assets/a54237af-8d8c-4cf4-9317-e5151ec26b26">
<img width="635" alt="Screenshot 2024-08-13 at 17 31 28" src="https://github.com/user-attachments/assets/c66e00c6-182d-4caa-ac56-f0caf1f7e162">
