### PR TITLE
feat: 자신의 기록인지 확인할 수 있는 필드 추가

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryValidator.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryValidator.java
@@ -10,7 +10,7 @@ public class MemoryValidator {
         }
     }
 
-    public static Boolean validateMyMemory(Long memoryMemberId, Long requestMemberId) {
+    public static Boolean isMyMemory(Long memoryMemberId, Long requestMemberId) {
         return memoryMemberId.equals(requestMemberId);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryValidator.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryValidator.java
@@ -9,4 +9,8 @@ public class MemoryValidator {
             throw new ForbiddenException(MemoryErrorType.FORBIDDEN);
         }
     }
+
+    public static Boolean validateMyMemory(Long memoryMemberId, Long requestMemberId) {
+        return memoryMemberId.equals(requestMemberId);
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -103,10 +103,7 @@ public class MemoryResponse {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String diary;
 
-    @Schema(
-            description = "자신의 글이라면 true, 아니라면 false",
-            example = "true",
-            type = "boolean")
+    @Schema(description = "자신의 글이라면 true, 아니라면 false", example = "true", type = "boolean")
     private Boolean isMyMemory;
 
     @Builder

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -103,6 +103,12 @@ public class MemoryResponse {
             requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String diary;
 
+    @Schema(
+            description = "자신의 글이라면 true, 아니라면 false",
+            example = "true",
+            type = "boolean")
+    private Boolean isMyMemory;
+
     @Builder
     public MemoryResponse(
             Long id,
@@ -116,7 +122,8 @@ public class MemoryResponse {
             LocalTime startTime,
             LocalTime endTime,
             Short lane,
-            String diary) {
+            String diary,
+            Boolean isMyMemory) {
         // 영법 별 바퀴 수와 미터 수를 계산
         List<StrokeResponse> resultStrokes = getResultStrokes(strokes, lane);
 
@@ -147,6 +154,7 @@ public class MemoryResponse {
         this.totalLap = totalLap;
         this.totalMeter = totalMeter;
         this.diary = diary;
+        this.isMyMemory = isMyMemory;
     }
 
     private static MemoryDetailResponse getMemoryDetail(MemoryDetail memoryDetail) {
@@ -205,6 +213,27 @@ public class MemoryResponse {
                 .endTime(memory.getEndTime())
                 .lane(memory.getLane())
                 .diary(memory.getDiary())
+                .build();
+    }
+
+    public static MemoryResponse from(Memory memory, Boolean isMyMemory) {
+        MemberSimpleResponse memberSimple =
+                new MemberSimpleResponse(
+                        memory.getMember().getGoal(), memory.getMember().getNickname());
+        return MemoryResponse.builder()
+                .id(memory.getId())
+                .member(memberSimple)
+                .pool(memory.getPool())
+                .memoryDetail(memory.getMemoryDetail())
+                .type(memory.classifyType())
+                .strokes(memory.getStrokes())
+                .images(memory.getImages())
+                .recordAt(memory.getRecordAt())
+                .startTime(memory.getStartTime())
+                .endTime(memory.getEndTime())
+                .lane(memory.getLane())
+                .diary(memory.getDiary())
+                .isMyMemory(isMyMemory)
                 .build();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -86,7 +86,7 @@ public class MemoryFacade {
 
     public MemoryResponse findById(Long memberId, Long memoryId) {
         Memory memory = getMemoryUseCase.findById(memoryId);
-//        validatePermission(memory.getMember().getId(), memberId);
+        // validatePermission(memory.getMember().getId(), memberId);
         Boolean isMyMemory = memory.getMember().getId().equals(memberId);
         return MemoryResponse.from(memory, isMyMemory);
     }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -1,5 +1,6 @@
 package com.depromeet.memory.facade;
 
+import static com.depromeet.memory.service.MemoryValidator.validateMyMemory;
 import static com.depromeet.memory.service.MemoryValidator.validatePermission;
 
 import com.depromeet.image.port.in.ImageUploadUseCase;
@@ -86,8 +87,7 @@ public class MemoryFacade {
 
     public MemoryResponse findById(Long memberId, Long memoryId) {
         Memory memory = getMemoryUseCase.findById(memoryId);
-        // validatePermission(memory.getMember().getId(), memberId);
-        Boolean isMyMemory = memory.getMember().getId().equals(memberId);
+        Boolean isMyMemory = validateMyMemory(memory.getMember().getId(), memberId);
         return MemoryResponse.from(memory, isMyMemory);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -86,8 +86,9 @@ public class MemoryFacade {
 
     public MemoryResponse findById(Long memberId, Long memoryId) {
         Memory memory = getMemoryUseCase.findById(memoryId);
-        validatePermission(memory.getMember().getId(), memberId);
-        return MemoryResponse.from(memory);
+//        validatePermission(memory.getMember().getId(), memberId);
+        Boolean isMyMemory = memory.getMember().getId().equals(memberId);
+        return MemoryResponse.from(memory, isMyMemory);
     }
 
     public TimelineSliceResponse getTimelineByMemberIdAndCursorAndDate(

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -1,6 +1,6 @@
 package com.depromeet.memory.facade;
 
-import static com.depromeet.memory.service.MemoryValidator.validateMyMemory;
+import static com.depromeet.memory.service.MemoryValidator.isMyMemory;
 import static com.depromeet.memory.service.MemoryValidator.validatePermission;
 
 import com.depromeet.image.port.in.ImageUploadUseCase;
@@ -87,7 +87,7 @@ public class MemoryFacade {
 
     public MemoryResponse findById(Long memberId, Long memoryId) {
         Memory memory = getMemoryUseCase.findById(memoryId);
-        Boolean isMyMemory = validateMyMemory(memory.getMember().getId(), memberId);
+        Boolean isMyMemory = isMyMemory(memory.getMember().getId(), memberId);
         return MemoryResponse.from(memory, isMyMemory);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #206

## 📌 작업 내용 및 특이사항
- 수영 기록 단일 조회 api에서, 자신의 글일 때/아닐 때를 구분할 필요가 있습니다.
- 나의 기록일 때와 아닐 때를 구분할 수 있는 boolean 데이터를 포함해서 응답할 수 있도록 `isMyMemory` 필드를 추가하였습니다.

## 📝 참고사항
- <mark>수영 기록 단일 조회는 제가 구현을 시작하였는데, 어느 순간부터 **자신의 기록만** 조회가 가능하도록 `validatePermission` 메서드가 추가되었습니다.</mark>
- <mark>이 코드를 누가 추가하였는지, 왜 추가하였는지 확인해 주시면 감사하겠습니다.(PR을 살펴보았으나 명확히 누가 추가했는지 확인할 수가 없었습니다.)</mark>
- 나의 기록인 경우
<img width="840" alt="Screenshot 2024-08-13 at 18 32 45" src="https://github.com/user-attachments/assets/28fe9176-72e5-4dfd-b1f3-4a89ca9266b4">

- 나의 기록이 아닌 경우
<img width="844" alt="Screenshot 2024-08-13 at 18 57 55" src="https://github.com/user-attachments/assets/ab9514fb-286f-4ae3-ae76-d0384432a89e">