### PR TITLE
refactor: 수영장 최근 검색 중복 제거

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/pool/facade/PoolFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/facade/PoolFacade.java
@@ -61,7 +61,18 @@ public class PoolFacade {
     public PoolInitialResponse getFavoriteAndSearchedPools(Long memberId) {
         List<PoolSearch> searchedPools = initialSearchUseCase.getSearchedPools(memberId);
         List<FavoritePool> favoritePools = initialSearchUseCase.getFavoritePools(memberId);
-        return PoolInitialResponse.of(favoritePools, searchedPools);
+
+        Set<Long> favoritePoolIds =
+                favoritePools.stream().map(it -> it.getPool().getId()).collect(Collectors.toSet());
+
+        List<PoolSearch> filteredSearchedPools =
+                searchedPools.stream()
+                        .filter(
+                                poolSearch ->
+                                        !favoritePoolIds.contains(poolSearch.getPool().getId()))
+                        .toList();
+
+        return PoolInitialResponse.of(favoritePools, filteredSearchedPools);
     }
 
     private Set<Long> getFavoritePoolIds(List<FavoritePool> favoritePools) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #220 

## 📌 작업 내용 및 특이사항
- 수영장 즐겨찾기와 최근 검색 둘 다 포함되어 있을 경우 중복이 되는 문제를 해결했습니다.