### PR TITLE
fix: 캘린더 조회 시 laps만 입력되어 있는 경우 meter 가 0으로 나오는 문제 해결

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
@@ -135,4 +135,14 @@ public class Memory {
         this.memoryDetail = null;
         return this;
     }
+
+    public int getLaneFromMemoryOrPool() {
+        if (this.lane != null && this.lane != 0) {
+            return this.lane;
+        }
+        if (this.pool != null) {
+            return this.pool.getLane() != null ? this.pool.getLane() : 0;
+        }
+        return 0;
+    }
 }

--- a/module-domain/src/main/java/com/depromeet/memory/domain/Stroke.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Stroke.java
@@ -41,4 +41,14 @@ public class Stroke {
         }
         return this.meter;
     }
+
+    public Integer getMeter(int lane) {
+        if (this.meter != null && this.meter != 0) {
+            return this.meter;
+        }
+        if (this.laps != null && this.laps != 0) {
+            return (int) (this.laps * 2 * lane);
+        }
+        return 0;
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/CalendarResponse.java
@@ -36,11 +36,7 @@ public class CalendarResponse {
                         it ->
                                 StrokeResponse.builder()
                                         .name(it.getName())
-                                        .meter(
-                                                it.getMeter() == null
-                                                        ? (int) (it.getLaps() * 2)
-                                                                * memoryDomain.getPool().getLane()
-                                                        : it.getMeter())
+                                        .meter(it.getMeter(memoryDomain.getLaneFromMemoryOrPool()))
                                         .build())
                 .toList();
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #326 

## 📌 작업 내용 및 특이사항
![image](https://github.com/user-attachments/assets/0281ea9c-f491-4e0b-b5cb-505572d65d4e)

laps 만 입력되어 있는 경우에도 meter가 표시되도록 수정하였습니다.

## 📝 참고사항
수정 결과

laps 가 4, meter 가 0으로 입력되어 있는 memory_id = 33 인 데이터
![image](https://github.com/user-attachments/assets/e158ac3e-fc4c-4927-a239-07677e73b7d4)

캘린더 조회 결과 memory_id = 33 인 데이터 조회 시 meter 가 계산되어서 나옵니다.
![image](https://github.com/user-attachments/assets/96898800-14c0-4509-931f-30fa8a86499e)

