### PR TITLE
fix: 서로 친구일 시 팔로우 로그 상태 변경 버그 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/notification/domain/FollowLog.java
+++ b/module-domain/src/main/java/com/depromeet/notification/domain/FollowLog.java
@@ -33,4 +33,8 @@ public class FollowLog {
     public void read() {
         this.hasRead = true;
     }
+
+    public void updateType(FollowType type) {
+        this.type = type;
+    }
 }

--- a/module-domain/src/main/java/com/depromeet/notification/port/out/FollowLogPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/out/FollowLogPersistencePort.java
@@ -18,4 +18,6 @@ public interface FollowLogPersistencePort {
     boolean existsByReceiverIdAndFollowerId(Long receiverId, Long followerId);
 
     List<Long> getFriendList(Long memberId, List<Long> followerIds);
+
+    void modifyFollowType(Long receiverId, Long followerId);
 }

--- a/module-domain/src/main/java/com/depromeet/notification/service/FollowLogService.java
+++ b/module-domain/src/main/java/com/depromeet/notification/service/FollowLogService.java
@@ -42,6 +42,10 @@ public class FollowLogService
                         .orElse("FOLLOW");
         FollowType followType = FollowType.valueOf(typeString);
 
+        if (followType.equals(FollowType.FRIEND)) {
+            followLogPersistencePort.modifyFollowType(followerId, receiverId);
+        }
+
         FollowLog followLog =
                 FollowLog.builder()
                         .receiver(event.receiver())

--- a/module-domain/src/test/java/com/depromeet/mock/notification/FakeFollowLogRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/notification/FakeFollowLogRepository.java
@@ -3,6 +3,7 @@ package com.depromeet.mock.notification;
 import com.depromeet.friend.domain.Friend;
 import com.depromeet.member.domain.Member;
 import com.depromeet.notification.domain.FollowLog;
+import com.depromeet.notification.domain.FollowType;
 import com.depromeet.notification.port.out.FollowLogPersistencePort;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -100,5 +101,15 @@ public class FakeFollowLogRepository implements FollowLogPersistencePort {
                 .filter(friend -> followerIds.contains(friend.getFollowing().getId()))
                 .map(friend -> friend.getFollowing().getId())
                 .toList();
+    }
+
+    @Override
+    public void modifyFollowType(Long receiverId, Long followerId) {
+        followLogDatabase.values().stream()
+                .filter(
+                        followLog ->
+                                followLog.getReceiver().getId().equals(receiverId)
+                                        && followLog.getFollower().getId().equals(followerId))
+                .forEach(followLog -> followLog.updateType(FollowType.FRIEND));
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/FollowLogRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/FollowLogRepository.java
@@ -98,6 +98,15 @@ public class FollowLogRepository implements FollowLogPersistencePort {
                 .toList();
     }
 
+    @Override
+    public void modifyFollowType(Long receiverId, Long followerId) {
+        queryFactory
+                .update(followLogEntity)
+                .where(memberEq(receiverId), followerEq(followerId))
+                .set(followLogEntity.type, PersistenceFollowType.FRIEND)
+                .execute();
+    }
+
     private BooleanExpression isFriendMember(Long memberId) {
         return friendEntity.member.id.eq(memberId);
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #467 

## 📌 작업 내용 및 특이사항
- 서로 친구일 시 팔로우 로그 상태가 변경되지 않아 계속 팔로우가 가능한 버튼으로 남아있는 버그를 수정하였습니다.

## 📝 참고사항
`[기존 상태 - 서로 맞팔 상태여도 기존 로그가 FOLLOW로 남아있어 팔로우 가능한 버튼 상태로 남아 있음]`
![image](https://github.com/user-attachments/assets/afccac7d-6261-4479-be9a-bffc8e4d9f03)

`[작업 후]`
<img width="450" alt="스크린샷 2024-12-03 오후 1 30 26" src="https://github.com/user-attachments/assets/3383bb93-0786-4ff3-8fb2-0ce30b1b5412">
<img width="459" alt="스크린샷 2024-12-03 오후 1 30 33" src="https://github.com/user-attachments/assets/fce24c3c-4b8c-4bff-93b0-1c21a64c4aba">


