### PR TITLE
refactor: 구글 스프레드 시트 API 호출 시 @Retryable 을 활용한 재처리 로직 추가

### DIFF
--- a/module-domain/src/main/java/com/depromeet/withdrawal/port/out/persistence/WithdrawalReasonPort.java
+++ b/module-domain/src/main/java/com/depromeet/withdrawal/port/out/persistence/WithdrawalReasonPort.java
@@ -3,5 +3,5 @@ package com.depromeet.withdrawal.port.out.persistence;
 import com.depromeet.withdrawal.domain.ReasonType;
 
 public interface WithdrawalReasonPort {
-    void writeToSheet(ReasonType reasonType, String feedback);
+    void writeWithdrawalToSheet(ReasonType reasonType, String feedback);
 }

--- a/module-domain/src/main/java/com/depromeet/withdrawal/service/WithdrawalReasonService.java
+++ b/module-domain/src/main/java/com/depromeet/withdrawal/service/WithdrawalReasonService.java
@@ -20,6 +20,6 @@ public class WithdrawalReasonService implements CreateWithdrawalReasonUseCase {
     public void save(CreateWithdrawalReasonCommand withdrawalReasonCommand) {
         ReasonType reasonType = ReasonType.findByCode(withdrawalReasonCommand.reasonCode());
         String feedback = withdrawalReasonCommand.feedback();
-        withdrawalReasonPort.writeToSheet(reasonType, feedback);
+        withdrawalReasonPort.writeWithdrawalToSheet(reasonType, feedback);
     }
 }

--- a/module-independent/src/main/java/com/depromeet/exception/GoogleSheetException.java
+++ b/module-independent/src/main/java/com/depromeet/exception/GoogleSheetException.java
@@ -1,0 +1,7 @@
+package com.depromeet.exception;
+
+public class GoogleSheetException extends RuntimeException {
+    public GoogleSheetException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/module-independent/src/main/java/com/depromeet/type/report/ReportErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/report/ReportErrorType.java
@@ -3,7 +3,8 @@ package com.depromeet.type.report;
 import com.depromeet.type.ErrorType;
 
 public enum ReportErrorType implements ErrorType {
-    CANNOT_REPORT_OWN_MEMORY("REPORT_1", "자신의 기록을 신고할 수 없습니다");
+    CANNOT_REPORT_OWN_MEMORY("REPORT_1", "자신의 기록을 신고할 수 없습니다"),
+    FAILED_TO_INSERT_DATA_TO_SPREADSHEET("REPORT_2", "스프레드시트(신고) 업데이트에 실패하였습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/withdrawal/WithdrawalReasonErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/withdrawal/WithdrawalReasonErrorType.java
@@ -3,7 +3,7 @@ package com.depromeet.type.withdrawal;
 import com.depromeet.type.ErrorType;
 
 public enum WithdrawalReasonErrorType implements ErrorType {
-    FAILED_TO_INSERT_DATA_TO_SPREADSHEET("WITHDRAWAL_1", "스프레드시트 업데이트에 실패하였습니다"),
+    FAILED_TO_INSERT_DATA_TO_SPREADSHEET("WITHDRAWAL_1", "스프레드시트(탈퇴 사유) 업데이트에 실패하였습니다"),
     REASON_CODE_NOT_FOUND("WITHDRAWAL_2", "해당 사유 코드는 존재하지 않는 코드입니다");
 
     private final String code;

--- a/module-infrastructure/google-spreadsheet/build.gradle
+++ b/module-infrastructure/google-spreadsheet/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation project(':module-independent')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.11.0'
     implementation 'com.google.apis:google-api-services-sheets:v4-rev612-1.25.0'
 }

--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/GoogleSheetConfig.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/GoogleSheetConfig.java
@@ -4,5 +4,5 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = SpreadSheetProperties.class)
-public class ScanningPropertiesConfig {}
+@EnableConfigurationProperties(value = {SpreadSheetProperties.class, ImageDomainProperties.class})
+public class GoogleSheetConfig {}

--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/ImageDomainProperties.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/ImageDomainProperties.java
@@ -1,0 +1,6 @@
+package com.depromeet.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud-front")
+public record ImageDomainProperties(String domain) {}

--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/RetryConfig.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/RetryConfig.java
@@ -1,0 +1,8 @@
+package com.depromeet.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #469 

## 📌 작업 내용 및 특이사항
1. GoogleSheetManager의 탈퇴 사유, 신고 등록 메서드에 `@Retryable`을 추가하였습니다.
2. 탈퇴 사유 신고 메서드 이름을 변경하였습니다. (writeToSheet -> writeWithdrawalToSheet)
3. 필드 주입 방식(`@Value`)으로 cloudFront 도메인을 가져오던 것을 생성자 주입 방식(`@ConfigurationProperties`)로 가져오는 방식으로 변경했습니다.
4. 탈퇴 사유와 신고 등록 ErrorType을 분리하였습니다.


## 📝 참고사항
아래는 테스트 결과입니다. (구글 스프레드 시트 환경변수는 모두 제것으로 변경 후 테스트를 진행하여 실제 구글 스프레드 시트 이름과 다릅니다.)

1. 탈퇴 사유 등록 API 200OK
![탈퇴 사유  retryable 200](https://github.com/user-attachments/assets/a0541c70-e3b9-44cc-b0d4-0ab8eec86f0a)
![탈퇴 사유 retryable 스프레드 시트에 추가됨](https://github.com/user-attachments/assets/27fa2881-dcd3-4f21-894c-dbc0871c18a1)

2. 신고 등록 API 200OK
![신고 사유 retryable 200](https://github.com/user-attachments/assets/81b73edc-733f-4bbb-97a6-57eb006610fd)
![신고 사유 retryable 엑셀 결과](https://github.com/user-attachments/assets/587613cd-a04d-4ba8-8b4d-e5297ff86233)

3. 탈퇴 사유, 신고 등록 예외 처리
writeWithdrawalToSheet 메서드에 일부러 예외를 던져 3회 시도 후 `@Recover` 에서 처리를 하는지 확인해봤습니다.
![탈퇴사유 retryable 일부러 예외처리](https://github.com/user-attachments/assets/1f900581-27e3-4866-a87d-5ffa3d57d6ee)

확인 결과 3번 시도 후, `@Recover`에서 예외를 처리하는 것을 확인할 수 있었습니다.
![탈퇴사유 retryable 실패](https://github.com/user-attachments/assets/9a633cbd-a8d2-485e-baea-0ebdad53bb94)
![로그 확인 결과](https://github.com/user-attachments/assets/8ba8d313-9f54-4036-86cb-83721d9ea236)


신고 등록 메서드에도 똑같이 적용 한 다음, 3회 시도 후 `@Recover` 에서 처리를 하는지 확인해봤습니다.
![신고 retryable 500](https://github.com/user-attachments/assets/0d1c860c-0e05-4faa-8f95-05b1537e67ea)
![신고 retryable 실패 로그](https://github.com/user-attachments/assets/f3ddba14-eb52-47f8-acd8-e10d4a9b4ee5)



