### PR TITLE
chore: Jenkins에서 이루어지던 CICD 를 github actions 로 이전

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,0 +1,94 @@
+name: Github Actions CI/CD flow
+
+on:
+  push:
+    branches: ["develop"]
+
+env:
+  DOCKER_USER: ${{ secrets.DOCKERHUB_USR }}
+  DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  DOCKER_REPO: ${{ secrets.DOCKERHUB_REPO }}
+  HOST_USER: ${{secrets.HOST_USER}} # ec2 username
+  TARGET_HOST: ${{ secrets.TARGET_HOST }}
+  PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ROLE: ${{ secrets.AWS_ROLE_ARN }} # AWS 보안 그룹 접근 Role
+  AWS_SG_ID: ${{ secrets.AWS_SG_ID }} # ec2 보안 그룹 ID
+
+permissions:
+  id-token: write
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx # docker multiplatform
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: ./scripts/Dockerfile-prod
+          push: true
+          tags: ${{ env.DOCKER_REPO }}:latest
+
+  CD:
+    needs: [CI]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get Github Action IP
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Add Github Actions IP to SG # github actions 의  IP를 SG 에 추가하여 접근 가능하게끔 설정
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
+      - name: Send deploy.sh to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ env.TARGET_HOST }}
+          username: ${{ env.EC2_SSH_USER }}
+          key: ${{ env.PRIVATE_KEY }}
+          source: "./scripts/shell/deploy.sh" # 배포 스크립트 위치
+          target: "/home/ec2-user"
+          strip_components: 2 # 숫자만큼 source의 선행 경로 제거
+          overwrite: true
+
+
+      - name: Docker Image Pull and Container run
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ env.EC2_HOST }}
+          username: ${{ env.EC2_SSH_USER }}
+          key: ${{ env.PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user
+            chmod +x deploy.sh
+            ./deploy.sh
+
+      - name: Remove Github Action IP from SG
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,7 @@ name: Github Actions CI/CD flow
 
 on:
   push:
-    branches: ["develop"]
+    branches: ["main"]
 
 env:
   DOCKER_USER: ${{ secrets.DOCKERHUB_USR }}
@@ -69,26 +69,25 @@ jobs:
         uses: appleboy/scp-action@master
         with:
           host: ${{ env.TARGET_HOST }}
-          username: ${{ env.EC2_SSH_USER }}
+          username: ${{ env.HOST_USER }}
           key: ${{ env.PRIVATE_KEY }}
-          source: "./scripts/shell/deploy.sh" # 배포 스크립트 위치
-          target: "/home/ec2-user"
+          source: "scripts/shell/deploy.sh" # 배포 스크립트 위치
+          target: /home/ubuntu/deploy
           strip_components: 2 # 숫자만큼 source의 선행 경로 제거
-          overwrite: true
 
 
       - name: Docker Image Pull and Container run
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ env.EC2_HOST }}
-          username: ${{ env.EC2_SSH_USER }}
+          host: ${{ env.TARGET_HOST }}
+          username: ${{ env.HOST_USER }}
           key: ${{ env.PRIVATE_KEY }}
           script: |
-            cd /home/ec2-user
+            docker login -u ${{ env.DOCKER_USER }} -p ${{ env.DOCKER_TOKEN }}
+            cd /home/ubuntu/deploy
             chmod +x deploy.sh
             ./deploy.sh
 
       - name: Remove Github Action IP from SG
         run: |
           aws ec2 revoke-security-group-ingress --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
-

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -25,19 +25,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to DockerHub
+      - name: Login to DockerHub # Dockerhub 로그인
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USER }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      - name: Set up QEMU
+      - name: Set up QEMU  # docker multiplatform 대응
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx # docker multiplatform
+      - name: Set up Docker Buildx # docker multiplatform 대응
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      - name: Build and push # 도커 파일 빌드 및 도커허브로 푸시
         uses: docker/build-push-action@v6
         with:
           file: ./scripts/Dockerfile-prod
@@ -45,7 +45,7 @@ jobs:
           tags: ${{ env.DOCKER_REPO }}:latest
 
   CD:
-    needs: [CI]
+    needs: [CI] # CI 진행 후 실행
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -57,11 +57,11 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get Github Action IP
+      - name: Get Github Action IP # github actions 가 실행되는 IP 를 얻어옵니다
         id: ip
         uses: haythem/public-ip@v1.3
 
-      - name: Add Github Actions IP to SG # github actions 의  IP를 SG 에 추가하여 접근 가능하게끔 설정
+      - name: Add Github Actions IP to SG # github actions 의  IP를 SG 에 추가하여 접근 가능하게끔 설정합니다.
         run: |
           aws ec2 authorize-security-group-ingress --group-id ${{ env.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
 
@@ -76,7 +76,7 @@ jobs:
           strip_components: 2 # 숫자만큼 source의 선행 경로 제거
 
 
-      - name: Docker Image Pull and Container run
+      - name: Docker Image Pull and Container run # ssh 를 통해 원격서버에 명령어를 실행합니다.
         uses: appleboy/ssh-action@master
         with:
           host: ${{ env.TARGET_HOST }}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #471 

## 📌 작업 내용 및 특이사항
- jenkins에서 이뤄지던 CICD를 github actions 로 이전하기 위해 스크립트를 작성했습니다. 
- 해당 스크립트는 main 브랜치로 푸시 이벤트가 발생할 때 작동합니다. 
- 대략적인 플로우는 아래와 같습니다. 
  - CI  
    - 기존의 Dockerfile-prod 로 도커 컨테이너 빌드
    - 빌드 된 이미지를 Dockerhub로 push
  - CD
    - github actions에서 원격 서버(ec2)로 ssh 접근 하기 위해 AWS Security Group에 github actions 의 IP 를 추가 (22번 포트)
    - github actions에서 원격 서버로 scp명령어로 deploy.sh 파일 전송
    - github actions에서 원격 서버로 ssh명령어로 deploy.sh 실행

## 📝 참고사항
- ec2 구축이 완료되는대로 테스트를 진행해볼 예정입니다. (현재 개인 AWS 계정에서 테스트를 한 결과 ec2에서 dockerhub 이미지를 받아오는 것까지 성공)